### PR TITLE
networkd: no networkd handling of tun IFs

### DIFF
--- a/systemd/network/calico.network
+++ b/systemd/network/calico.network
@@ -1,0 +1,7 @@
+# Exclude calico ipip tunnel devices from DHCP by default
+
+[Match]
+Name=cali*
+
+[Link]
+Unmanaged=yes

--- a/systemd/network/cni.network
+++ b/systemd/network/cni.network
@@ -1,0 +1,7 @@
+# Exclude kubernetes CNI devices from DHCP by default
+
+[Match]
+Name=cni*
+
+[Link]
+Unmanaged=yes

--- a/systemd/network/docker.network
+++ b/systemd/network/docker.network
@@ -1,7 +1,0 @@
-# Exclude docker devices from DHCP by default
-
-[Match]
-Name=docker*
-
-[Link]
-Unmanaged=yes

--- a/systemd/network/docker.network
+++ b/systemd/network/docker.network
@@ -1,0 +1,7 @@
+# Exclude docker devices from DHCP by default
+
+[Match]
+Name=docker*
+
+[Link]
+Unmanaged=yes

--- a/systemd/network/ipsec-vti.network
+++ b/systemd/network/ipsec-vti.network
@@ -1,0 +1,7 @@
+# Exclude IPSEC vti devices from DHCP by default
+
+[Match]
+Name=vti*
+
+[Link]
+Unmanaged=yes


### PR DESCRIPTION
This change prevents networkd interference with virtual/tunnel
devices for IPSEC (vti*), docker's virtual interfaces (docker*),
and Calico's virtual interfaces (cali*).

This fixes issues introduced by networkd interference we observed
with IPSEC interfaces in particular (tunnel virtual IP being
de-configured and tunnel route torn down at interface activation
time). It also aims to prevent future issues with docker and Calico.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>