### PR TITLE
tests/coreos-install: use ignition.config.url instead of flatcar.config.url

### DIFF
--- a/tests/coreos-install/register/register.go
+++ b/tests/coreos-install/register/register.go
@@ -244,7 +244,7 @@ func (test Test) ValidateIgnition(t *testing.T, rootDir, config string) {
 		t.Fatalf("reading grub.cfg: %v", err)
 	}
 
-	if !util.RegexpContains(t, "flatcar.config.url=oem:///flatcar-install.json", data) {
+	if !util.RegexpContains(t, "ignition.config.url=oem:///flatcar-install.json", data) {
 		t.Fatalf("grub.cfg doesn't contain a reference to flatcar-install.json: %s", data)
 	}
 }


### PR DESCRIPTION
Since upstream changed the config URL to `ignition.config.url`, we should also replace `flatcar.config.url` with `ignition.config.url`.