### PR TITLE
flatcar-install: make default_board support arm64

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -16,6 +16,7 @@ default_board() {
     fi
 
     case "$(uname -m)" in
+    aarch64 ) echo "arm64-usr" ;;
     * )       echo "amd64-usr" ;;
     esac
 }


### PR DESCRIPTION
To make flatcar-install support ARM64 architecture, we should make `default_board()` return `arm64-usr` in case of ARM64.

Then we can support ARM64 by simply reading `/usr/share/flatcar/release` at runtime.