### PR TITLE
install: Create symlink for flatcar-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install:
 		$(DESTDIR)/usr/share/logrotate \
 		$(DESTDIR)/usr/share/ssh
 	install -m 755 bin/* $(DESTDIR)/usr/bin
+	ln -sf flatcar-install $(DESTDIR)/usr/bin/coreos-install
 	install -m 755 scripts/* $(DESTDIR)/usr/lib/flatcar
 	install -m 644 systemd/network/* $(DESTDIR)/usr/lib/systemd/network
 	install -m 755 systemd/system-generators/* \


### PR DESCRIPTION
To ease migration of Ignition configurations
that call coreos-install, provide a symlink to
flatcar-install.

Note: Should also be picked for edge and alpha, and then needs a new commit ID in coreos-overlay, again also in edge and alpha.