### PR TITLE
flatcar-autologin-generator: Support coreos.autologin

### DIFF
--- a/systemd/system-generators/flatcar-autologin-generator
+++ b/systemd/system-generators/flatcar-autologin-generator
@@ -74,8 +74,11 @@ autologin() {
 read -r CMDLINE </proc/cmdline;
 
 for i in $CMDLINE; do
-    case "$i" in
-         flatcar.autologin*) autologin "$i" ;;
-    esac
+    prefix="$(echo "$i" | awk -F'.' '{print $1}')"
+    if [ "$prefix" = "coreos" ] || [ "$prefix" = "flatcar" ]; then
+        case "$i" in
+             *.autologin*) autologin "$i" ;;
+        esac
+    fi
 done
 


### PR DESCRIPTION
If the user does not have the new name specified
in the boot loader, the out of band console would
require a password which may not exist.