### PR TITLE
bin/flatcar-install: Describe that setting OEM uses an OEM image

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -77,7 +77,7 @@ Options:
     -C CHANNEL  Release channel to use (e.g. beta) [default: ${CHANNEL_ID}].
     -I|e <M,..> EXPERIMENTAL (used with -s): List of major device numbers to in-/exclude
                 when finding the smallest disk.
-    -o OEM      OEM type to install (e.g. ami) [default: ${OEM_ID:-(none)}].
+    -o OEM      OEM type to install (e.g. ami), using flatcar_production_<OEM>_image.bin.bz2 [default: ${OEM_ID:-(none)}].
     -c CLOUD    Insert a cloud-init config to be executed on boot.
     -i IGNITION Insert an Ignition config to be executed on boot.
     -b BASEURL  URL to the image mirror (overrides BOARD and CHANNEL).


### PR DESCRIPTION
The description for -o OEM talks about an OEM type that is installed.
Add that this means that a different image will be used. This makes
it easier for users to relate this to the images we offer on the
release server.

# How to use/test

`bin/flatcar-install -h`

Note: Pick for all channels.