### PR TITLE
networkd: prevent networkd interference of weave network devices

### DIFF
--- a/systemd/network/weave.network
+++ b/systemd/network/weave.network
@@ -1,0 +1,7 @@
+# Exclude Weave Net devices from DHCP by default
+
+[Match]
+Name=weave datapath vxlan-6784
+
+[Link]
+Unmanaged=yes


### PR DESCRIPTION
# Prevent _networkd_ interference of weave network devices

This change prevents _systemd-networkd_ interference with 
the _Weave_ virtual interfaces `weave`, `datapath` and 
`vxlan-6784` are all created by _Weave_. Documentation on these
interfaces is available here:

* https://github.com/weaveworks/weave/blob/1ff09fd4d1c52bfa49222b724742f7b4bb80543a/net/bridge.go#L24-L54

This fixes DHCP issues introduced by _networkd_ interference 
reported by multiple users and mainly highlighted by this issue:

* https://github.com/weaveworks/weave/issues/3657

The issue doesn't seems to cause any significant impact on 
performance, however it will cause _Weave NPC_ to produce a 
high volume of the following repetitive warning logs.

`WARN: 2019/07/05 11:12:25.102451 UDP connection from 0.0.0.0:68 to 255.255.255.255:67 blocked by Weave NPC.`

# How to use

Having the `weave.network` file provided to _networkd_ should 
be enough.

# Testing done

We have run many Flatcar instances in production with this configuration enabled, for at least one full week. The instances
are part of a many _Kubernetes_ clusters using _Weave_ as their network overlay.
