### PR TITLE
Add a Match section for systemd to not ignore

### DIFF
--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -1,4 +1,5 @@
 [Match]
+Name=*
 KernelCommandLine=!root
 
 [Network]

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -1,6 +1,9 @@
 [Network]
 DHCP=yes
 
+[Match]
+Name=*
+
 [DHCP]
 UseMTU=true
 UseDomains=true


### PR DESCRIPTION
# Add a Match section for systemd to not ignore

systemd 245 ignores .link and .network files if the Match section is empty. More details in the [NEWS](https://github.com/systemd/systemd/blob/master/NEWS#L830-L833) entry. 

This should be merged with https://github.com/flatcar-linux/coreos-overlay/pull/448

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>

# How to use

```bash
emerge-amd54-usr coreos-base/coreos-init
```


# Testing done

Without these options, the SSH to the machine was broken, and no packets were received by the machine. This fixes the issue. 
