### PR TITLE
flatcar-install: support installation on multipath devices

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -357,7 +357,7 @@ if [[ -n "${INSTALL_TO_SMALLEST}" ]]; then
     fi
 fi
 
-if ! [[ $(lsblk -n -d -o TYPE "${DEVICE}") =~ ^(disk|loop|lvm)$ ]]; then
+if ! [[ $(lsblk -n -d -o TYPE "${DEVICE}") =~ ^(disk|mpath|loop|lvm)$ ]]; then
     echo "$0: Target block device (${DEVICE}) is not a full disk." >&2
     exit 1
 fi


### PR DESCRIPTION

# Allow installation to multipath target

I got the error "Target block device /dev/mapper/mpatha is not a full disk". I had to change line 360 in the /usr/bin/coreos-install script and add mpath. Now I can install on /dev/mapper/mpatha

https://github.com/flatcar-linux/coreos-overlay/pull/528


# How to use

systemctl start multipathd
coreos-install -d /dev/mapper/mpatha


# Testing done

it installs and comes up on a reboot.

