### PR TITLE
networkd: Add settings for Calico's IP-in-IP tunnel

### DIFF
--- a/systemd/network/20-calico-tunl0.link
+++ b/systemd/network/20-calico-tunl0.link
@@ -1,0 +1,7 @@
+# Disable TX offload for Calico's IP-in-IP tunnel to enforce checksum calculation
+[Match]
+OriginalName=tunl0
+Type=tunnel
+
+[Link]
+TransmitChecksumOffload=off

--- a/systemd/network/20-calico-tunl0.network
+++ b/systemd/network/20-calico-tunl0.network
@@ -1,0 +1,7 @@
+# Exclude Calico's IP-in-IP tunnel from configuration through networkd
+
+[Match]
+Name=tunl0
+
+[Link]
+Unmanaged=yes


### PR DESCRIPTION
The tunnel interface tunl0 was getting the default setup of DHCP
and TX offload. Since Calico set up the IP address, the interface
was working but thought to be in "configuring" state by networkd
which is harmless but still not optimal. Recently the TX offload
caused Pod-to-Pod communication through the tunnel to break because
the checksums were not calculated.
Set the tunnel interface to be not managed by networkd's default
setup with DHCP. Disable the TX offload to enforce checksum
calculation.
See https://github.com/flatcar-linux/Flatcar/issues/183



# How to use

Schedule two Kubernetes Pods on one node each with Calico and send UDP or TCP packets.

# Testing done

The files were manually placed on the node under `/etc/systemd/network`.