### PR TITLE
Do not create empty /etc/coreos symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ install:
 	install -m 644 configs/tmpfiles.d/* $(DESTDIR)/usr/lib/tmpfiles.d/
 	cp -a systemd/system/* $(DESTDIR)/usr/lib/systemd/system
 	ln -sf ../run/issue $(DESTDIR)/etc/issue
-	ln -sf flatcar $(DESTDIR)/etc/coreos
 	ln -sf flatcar $(DESTDIR)/usr/lib/coreos
 	ln -sf flatcar $(DESTDIR)/usr/share/coreos
 


### PR DESCRIPTION
The symlink had no target and was only working on the final image after
the target folder got created by some other component. Now the target
folder and symlink is created by a tmpfile directive in baselayout and
the symlink here conflicts with the baselayout package's file.
Remove it since it is a duplicate.

# How to use

Goes along with https://github.com/flatcar-linux/baselayout/pull/7

# Testing done

See linked PR.