### PR TITLE
network: Exclude new Azure driver as well

### DIFF
--- a/systemd/network/yy-azure-sriov-coreos.network
+++ b/systemd/network/yy-azure-sriov-coreos.network
@@ -9,7 +9,7 @@ KernelCommandLine=coreos.oem.id=azure
 # VF driver currently used in Azure. If other drivers come into use, the
 # symptom will be a VF interface in the output of "networkctl" which never
 # finishes configuring.
-Driver=mlx4_en
+Driver=mlx4_en mlx5_core
 
 [Link]
 Unmanaged=yes

--- a/systemd/network/yy-azure-sriov.network
+++ b/systemd/network/yy-azure-sriov.network
@@ -9,7 +9,7 @@ KernelCommandLine=flatcar.oem.id=azure
 # VF driver currently used in Azure. If other drivers come into use, the
 # symptom will be a VF interface in the output of "networkctl" which never
 # finishes configuring.
-Driver=mlx4_en
+Driver=mlx4_en mlx5_core
 
 [Link]
 Unmanaged=yes


### PR DESCRIPTION
The bonded SR-IOV interface should not be configured individually and
has to be set to unmanaged. This is done by looking for	the driver but
now a new driver is in use and the list	has to be expanded or otherwise
the interface is stuck in a degraded state causing the
systemd-networkd-wait-online.service target to fail.

# How to use

Goes together with https://github.com/flatcar-linux/bootengine/pull/19

Boot a machine as see if the `systemd-networkd-wait-online.service` failed or run the kola tests.


# Testing done

[Built an image](http://localhost:9091/job/os/job/manifest/1216/console), all [tests passing](http://localhost:9091/job/os/job/kola/job/azure/194/console)