### PR TITLE
network: Restore KeepConfiguration=dhcp-on-stop

### DIFF
--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -4,6 +4,7 @@ KernelCommandLine=!root
 
 [Network]
 DHCP=yes
+KeepConfiguration=dhcp-on-stop
 
 [DHCP]
 ClientIdentifier=mac

--- a/systemd/network/yy-vmware.network
+++ b/systemd/network/yy-vmware.network
@@ -3,6 +3,7 @@ Virtualization=vmware
 
 [Network]
 DHCP=yes
+KeepConfiguration=dhcp-on-stop
 
 [DHCP]
 UseMTU=true

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -1,5 +1,6 @@
 [Network]
 DHCP=yes
+KeepConfiguration=dhcp-on-stop
 
 [Match]
 Name=*


### PR DESCRIPTION
The default behavior in systemd-networkd was changed in v244 from
keeping the IP addresses and routes on service stop to deconfiguring
them:
https://github.com/systemd/systemd/commit/800603524a7ab076d40450286ff7802a04289b7f
Deconfiguring means that on system shutdown the DHCP address is
properly released but also has the side effect that orphaned processes
not part of a systemd unit don't have network connectivity when they
get the broadcasted SIGTERM.
Restore the previous behavior and hope that DHCP servers recognize
the system again on reboot and hand out the same address don't have to
rely on the address release (which, anyway, is not sent for a crashing
system either). The default can of course be changed by the user.
In the initramfs the KeepConfiguration=no behavior is desired because
otherwise the IP address is not released which can cause problems when
a different DHCP client configuration is set on first boot and the DHCP
server wouldn't be able to recognize the rootfs system and keep two
addresses allocated.

Fixes https://github.com/flatcar-linux/Flatcar/issues/213

# How to use/test

Boot a system that uses one of the modified configurations, e.g., a QEMU VM.
Then check
```
systemctl stop systemd-networkd
ip a
```
to report the interface as configured with an IP address.

# Testing done

Manually changed the default config in a QEMU VM.
Ran kola tests on all platforms. Verified that stopping networkd does not turn of QEMU networking.