### PR TITLE
extend-filesystems: More robustness against kernel partition re-reads

### DIFF
--- a/scripts/extend-filesystems
+++ b/scripts/extend-filesystems
@@ -20,6 +20,7 @@ mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT)
 for dev_info in "${DEV_LIST[@]}"; do
     eval "$dev_info"
     NAME=${NAME//\!//}
+    echo "Found ${NAME}"
     if [[ "${PARTTYPE}" != "${COREOS_RESIZE}" ]] || \
        [[ -z "${NAME}" ]] || \
        [[ -z "${MOUNTPOINT}" ]] || \
@@ -30,14 +31,22 @@ for dev_info in "${DEV_LIST[@]}"; do
     fi
 
     device="/dev/${NAME}"
+    echo "Checking size of ${device}"
     old_size=$(blockdev --getsz "${device}")
     cgpt resize "${device}"
 
     # Only resize filesystem if the partition changed
-    if [[ "${old_size}" -eq $(blockdev --getsz "${device}") ]]; then
+    # (need to retry in case udev triggered a kernel partition re-read which causes the device to disappear shortly,
+    # this condition here works under the assumption that we always get the new size because cgpt notifies the kernel
+    # about it before it touches the disk).
+    if [[ "${old_size}" -eq "$(for s in {1..20}; do if blockdev --getsz "${device}"; then break; fi; sleep 0.5; done)" ]]; then
+        echo "Old size kept for ${device}"
         continue
     fi
+    echo "Resized partition ${device}"
 
+    # The device may still disappear here because we can't know if udev already retriggered a full partition re-read
+    # (a solution could be to use synthetic uevent tagging or to rerun the resize commands a few times).
     case "${FSTYPE}" in
         "btrfs")
             # map the device name to the btrfs device id
@@ -52,4 +61,5 @@ for dev_info in "${DEV_LIST[@]}"; do
             xfs_growfs "${MOUNTPOINT}"
             ;;
     esac
+    echo "Resized filesystem in ${device}"
 done


### PR DESCRIPTION
Directly using the device after the resize is prone to races.
At least for the size check it's easy to retry until we succeed getting
the new size. The filesystem resize call may still fail but the service
is limited in this way already because at startup it only checks if the
partition size is maximal but not the filesystem size. For future
debugging the output is made more verbose.

https://github.com/kinvolk/Flatcar/issues/235

# How to use


# Testing done

See https://github.com/kinvolk/coreos-overlay/pull/689