### PR TITLE
networkd: avoid managing MAC addresses for veth devices

### DIFF
--- a/systemd/network/50-veth.link
+++ b/systemd/network/50-veth.link
@@ -1,0 +1,6 @@
+# Prevent systemd-networkd from handling the MACAddresses of veth devices
+[Match]
+Driver=veth
+
+[Link]
+MACAddressPolicy=none


### PR DESCRIPTION
When a veth device is created, the CNI in charge of bringing the device up will set a MAC address. If  `MACAddressPolicy=permanent` is set, systemd will change it to a different one, causing dropped packets due to mismatches.

With this change, the address set when the device is created will remain untouched by systemd.

See https://github.com/kinvolk/Flatcar/issues/278 for more information.

# Testing done

I've tested this manually, by creating the equivalent /etc file. I haven't tested it using a generated image. We currently don't have any kola tests that catch this, because we aren't testing any CNIs that use this. We already have a rule in place for flannel, the only one that we do test.