### PR TITLE
scripts/motdgen: Add OEM information to motd output

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -12,7 +12,11 @@ source /usr/lib/os-release
 
 mkdir -p /run/flatcar
 ln -sf flatcar /run/coreos
-echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m ${GROUP} (${VERSION})" > /run/flatcar/motd
+OEM=""
+if [ -f /usr/share/oem/oem-release ]; then
+  OEM="$(source /usr/share/oem/oem-release; echo " for $NAME")"
+fi
+echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m ${GROUP} (${VERSION})${OEM}" > /run/flatcar/motd
 
 if [[ -d "/etc/motd.d" ]]; then
 	cat /etc/motd.d/*.conf 2>/dev/null >> /run/flatcar/motd || true

--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -16,7 +16,7 @@ OEM=""
 if [ -f /usr/share/oem/oem-release ]; then
   OEM="$(source /usr/share/oem/oem-release; echo " for $NAME")"
 fi
-echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m ${GROUP} (${VERSION})${OEM}" > /run/flatcar/motd
+echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m ${GROUP} ${VERSION}${OEM}" > /run/flatcar/motd
 
 if [[ -d "/etc/motd.d" ]]; then
 	cat /etc/motd.d/*.conf 2>/dev/null >> /run/flatcar/motd || true


### PR DESCRIPTION
The message-of-the-day login greeter shows basic information about the
OS but so far did not give a hint whether an OEM variant is used and
which (e.g., "Flatcar Container Linux by Kinvolk stable (2605.12.0)").
Append the OEM name to it, like "for Amazon EC2".

# How to use

Build an OEM image and see that the name is shown at login


# Testing done

Only manual execution of the changed script lines