### PR TITLE
configs/sshd_config: use secure crypto algos only

### DIFF
--- a/configs/sshd_config
+++ b/configs/sshd_config
@@ -5,3 +5,6 @@ UseDNS no
 UsePAM yes
 PrintLastLog no # handled by PAM
 PrintMotd no # handled by PAM
+Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128-etm@openssh.com,umac-128@openssh.com
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256


### PR DESCRIPTION
Limit ciphers used by the SSH service to "known secure" only:

- Limit Ciphers to chacha20-poly1305@openssh.com
                   aes128-ctr,aes192-ctr
                   aes256-ctr,aes128-gcm@openssh.com
                   aes256-gcm@openssh.com

- Limit Message Authentication Codes to hmac-sha2-256-etm@openssh.com
                                        hmac-sha2-512-etm@openssh.com
                                        hmac-sha2-256,hmac-sha2-512
                                        umac-128-etm@openssh.com
                                        umac-128@openssh.com

- Limit Key Exchange Algorithms to curve25519-sha256
                                   curve25519-sha256@libssh.org
                                   ecdh-sha2-nistp256
                                   ecdh-sha2-nistp384
                                   ecdh-sha2-nistp521
                                   diffie-hellman-group-exchange-sha256
                                   diffie-hellman-group16-sha512
                                   diffie-hellman-group18-sha512
                                   diffie-hellman-group14-sha256
