### PR TITLE
bin/flatcar-install: detect device mapper usage

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -30,7 +30,8 @@ find_smallest_unused_disk() {
             drive=$(echo "$line" | awk '{print $1}')
             size=$(echo "$line" | awk '{print $2}')
             mountpoints=$(lsblk -ln -o MOUNTPOINT "$drive")
-            if [[ "$size" -gt 10000000000 ]] && [[ -z "$mountpoints" ]]; then
+            device_mapper_usages=$(lsblk -ln -o PATH "$drive" |  grep -v "^$drive")
+            if [[ "$size" -gt 10000000000 ]] && [[ -z "$mountpoints" ]] && [[ -z "${device_mapper_usages}" ]]; then
                 echo "$drive" "$size"
             fi
         done))"


### PR DESCRIPTION
The search for free disks was aware of mount points but did not
consider device mapper usage (e.g., LUKS or LVM) and went on to
overwrite the disk while it still was used. This can disrupt the
installation process or lead to unnoticed data corruption. It was also
not save when run on a system with active disk usage.
For disks with active device mapper entries the user must first remove
the mappings. For LVM this can be done with
lvchange -an /dev/mapper/PREFIX* (just /* also works to disable all LVM
mappings).

Fixes https://github.com/kinvolk/Flatcar/issues/332


## How to use

For PXE-based installation, add an `lvchange -an /dev/mapper/*` command before running `flatcar-install` to disable any present LVM partitions that got auto-activated.

## Testing done

[Equinix Metal kola tests](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2617/cldsv/)