### PR TITLE
systemd/network: don't manage the loopback interface

### DIFF
--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -4,6 +4,7 @@ KeepConfiguration=dhcp-on-stop
 
 [Match]
 Name=*
+Type=!loopback
 
 [DHCP]
 UseMTU=true


### PR DESCRIPTION
The default network configuration is DHCP and was also applied to the
loopback interface. This resulted in the loopback interface being in a
"managed" state in networkd and	sometimes caused the IP	address	to be
deconfigured, resulting in errors when something tries to make use of
the loopback interface, like resolved
(see https://flaviutamas.com/2019/fixing-name-resolution-after-sleep).
Exclude	the loopback interface from the	default	configuration to make
it "unmanaged".

Also see https://github.com/kinvolk/bootengine/pull/24

## How to use

See if nothing else breaks because of the change

## Testing done

[for all platforms](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/2618/cldsv/)