### PR TITLE
udev: add systemd tag for Azure storage devices

### DIFF
--- a/udev/rules.d/66-azure-storage.rules
+++ b/udev/rules.d/66-azure-storage.rules
@@ -21,7 +21,7 @@ GOTO="azure_end"
 
 # Create the symlinks
 LABEL="azure_names"
-ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
-ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}", TAG+="systemd"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n", TAG+="systemd"
 
 LABEL="azure_end"


### PR DESCRIPTION
Without the systemd tag no device units are created for the storage
devices. This causes the /boot automount dependency to be missing.

Add the systemd tag in udev for Azure storage devices, both on
partitions and the full disk.


## How to use/Testing done

See https://github.com/kinvolk/coreos-overlay/pull/1091