### PR TITLE
systemd: autodetect OEM partition filesystem

### DIFF
--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -13,4 +13,4 @@ ConditionPathExists=!/usr/.noupdate
 What=/dev/disk/by-label/OEM
 Where=/usr/share/oem
 Options=nodev
-Type=ext4
+Type=auto


### PR DESCRIPTION
When btrfs is used to fit more content into the partition, mounting
fails because ext4 was hardcoded.
Use the auto detection mechanism to find the filesystem type.

## How to use/Testing done

This was built and tested with the coreos-overlay branch `kai/bootengine-verity-hashoffset` from https://github.com/kinvolk/coreos-overlay/pull/1106 and flatcar-scripts branch `kai/btrfs-usr-oem` from https://github.com/kinvolk/flatcar-scripts/pull/131 in http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3029/cldsv/ where the Flatcar image that has a btrfs /usr partition and OEM partition.
While the actual switch to a btrfs filesystem on the /usr partition is only possible when all changes are part of a Stable release because update-engine needs to know how to handle the new filesystem when updating, we can already do the switch for the OEM partition.