### PR TITLE
networkd: prevent networkd interference with cilium_vxlan interface

### DIFF
--- a/systemd/network/20-cilium.network
+++ b/systemd/network/20-cilium.network
@@ -1,0 +1,7 @@
+# Exclude Cilium's vxlan interface (and any other Cilium interfaces) from configuration through networkd
+
+[Match]
+Name=cilium*
+
+[Link]
+Unmanaged=yes


### PR DESCRIPTION
Cilium's cilium_vxlan interface was getting the default networkd setup
applied which tries to attach an IP address through DHCP. This meant
that the interface was stuck in this "configuring" state by networkd
and now since somewhere between systemd 247.3 and 247.6 this also
causes a disruption, reported in
https://github.com/kinvolk/Flatcar/issues/455

Set the cilium_vxlan interface to be not managed by networkd's default
setup with DHCP as it's managed by Cilium.


## How to use

To verify, check `networkctl` output to have `cilium_vxlan` to be `unmanaged` instead of `configuring`. Also check that it fixes the mentioned issue with Stable 2905.2.0

## Testing done

Manually added the file to `/etc/systemd/network/` and verified that it fixed the reproducer and the kubeadm.cilium.base test and ran a full test http://localhost:9091/job/os/job/manifest/3158/cldsv/ for the commit here