### PR TITLE
add warning to motd when cgroupv1 is in use

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -22,6 +22,10 @@ if [[ -d "/etc/motd.d" ]]; then
 	cat /etc/motd.d/*.conf 2>/dev/null >> /run/flatcar/motd || true
 fi
 
+if ! ( mount | grep -q cgroup2 ); then
+	echo -e "\e[33mWarning\e[39m: using legacy cgroups" >> /run/flatcar/motd
+fi
+
 if [[ "${GROUP}" =~ "lts" ]]; then
 	echo "FCL LTS documentation: https://kinvolk.io/fcl-lts-docs" >> /run/flatcar/motd
 fi

--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -24,6 +24,7 @@ fi
 
 if ! ( mount | grep -q cgroup2 ); then
 	echo -e "\e[33mWarning\e[39m: using legacy cgroups" >> /run/flatcar/motd
+	echo -e "Read more: https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups" >> /run/flatcar/motd
 fi
 
 if [[ "${GROUP}" =~ "lts" ]]; then


### PR DESCRIPTION
The warning text is orange and will complement the "taint" warning that systemd v248 reports on such systems. This is part of the work to update to Docker 20.10 and Cgroup v2.

Part of kinvolk/coreos-overlay#931