### PR TITLE
bin/flatcar-install: randomize OEM filesystem UUID if mounting fails

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -656,7 +656,7 @@ function write_ignition() if [[ -n "${IGNITION}" ]]; then
     local OEM_DEV=$(blkid -t "LABEL=OEM" -o device "${DEVICE}"*)
 
     mkdir -p "${WORKDIR}/oemfs"
-    mount "${OEM_DEV}" "${WORKDIR}/oemfs"
+    mount "${OEM_DEV}" "${WORKDIR}/oemfs" || { btrfstune -f -u "${OEM_DEV}" ; mount "${OEM_DEV}" "${WORKDIR}/oemfs" ; }
     trap 'umount "${WORKDIR}/oemfs"' RETURN
 
     echo "Installing Ignition config ${IGNITION}..."

--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -85,7 +85,7 @@ Options:
     -C CHANNEL  Release channel to use (e.g. beta) [default: ${CHANNEL_ID}].
     -I|e <M,..> EXPERIMENTAL (used with -s): List of major device numbers to in-/exclude
                 when finding the smallest disk.
-    -o OEM      OEM type to install (e.g. ami), using flatcar_production_<OEM>_image.bin.bz2 [default: ${OEM_ID:-(none)}].
+    -o OEM      OEM type to install (e.g. 'ami' or '' to force none), using flatcar_production_<OEM>_image.bin.bz2 [default: ${OEM_ID:-(none, i.e., the empty string)}].
     -c CLOUD    Insert a cloud-init config to be executed on boot.
     -i IGNITION Insert an Ignition config to be executed on boot.
     -b BASEURL  URL to the image mirror (overrides BOARD and CHANNEL).

--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -70,6 +70,9 @@ for f in /usr/share/oem/oem-release /etc/oem-release; do
         eval "$(sed -e 's/^/OEM_/' $f)"
     fi
 done
+if [[ "${OEM_ID}" = "qemu" ]] || [[ "${OEM_ID}" = "qemu_uefi" ]]; then
+    OEM_ID=""
+fi
 
 USAGE="Usage: $0 {{-d <device>}|-s} [options]
 Options:


### PR DESCRIPTION
- bin/flatcar-install: randomize OEM filesystem UUID if mounting fails
    When an identical BTRFS filesystem is already mounted because the
    installing system has the same OEM partition version, the mounting
    of the installed OEM partition fails because identical UUIDs are
    only allowed to be used for btrfs multi device setups.
    Randomize the filesystem UUID in case mounting fails and try again.
-  bin/flatcar-install: do not try to use qemu OEM image
    The QEMU OEM image is qcow2 and can't be written to disk as is.
    Use the generic image and not the QEMU image when installing from QEMU.
- bin/flatcar-install: explain OEM flag

## How to use


## Testing done

1. Using the QEMU OEM image it does not show `qemu` as default OEM value in the `-h` ouput
2. Using `sudo ./flatcar-install -d /dev/vdb -i test.ign` on the Alpha release generic image, installing the generic image, `btrfstune`is invoked:
```
$ sudo ./flatcar-install -d /dev/vdb -i test.ign
Downloading the signature for https://alpha.release.flatcar-linux.net/amd64-usr/2969.0.0/flatcar_production_image.bin.bz2...
2021-08-31 12:12:36 URL:https://alpha.release.flatcar-linux.net/amd64-usr/2969.0.0/flatcar_production_image.bin.bz2.sig [594/594] -> "/tmp/flatcar-install.a2he5sYwpI/flatcar_production_image.bin.bz2.sig" [1]
Downloading, writing and verifying flatcar_production_image.bin.bz2...
2021-08-31 12:13:45 URL:https://alpha.release.flatcar-linux.net/amd64-usr/2969.0.0/flatcar_production_image.bin.bz2 [375637282/375637282] -> "-" [1]
gpg: Signature made Wed Aug 18 03:22:07 2021 UTC
gpg:                using RSA key 782B3BC9F10CF638A5DCF5105B2910CBFCBEAB91
gpg:                issuer "buildbot@flatcar-linux.org"
gpg: key E25D9AED0593B34A marked as ultimately trusted
gpg: checking the trustdb
gpg: marginals needed: 3  completes needed: 1  trust model: pgp
gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
gpg: Good signature from "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" [ultimate]
gpg: Note: This key has expired!
Primary key fingerprint: F88C FEDE FF29 A5B4 D952  3864 E25D 9AED 0593 B34A
     Subkey fingerprint: 782B 3BC9 F10C F638 A5DC  F510 5B29 10CB FCBE AB91
mount: /tmp/flatcar-install.a2he5sYwpI/oemfs: mount(2) system call failed: File exists.
Current fsid: 4281468d-2f64-468e-8af1-a722492b8bf9
New fsid: f7533d32-7ced-4e7c-a547-52ac86e8b747
Set superblock flag CHANGING_FSID
Change fsid in extents
Change fsid on devices
Clear superblock flag CHANGING_FSID
Fsid change finished
Installing Ignition config test...
Success! Flatcar Container Linux alpha 2969.0.0 is installed on /dev/vdb
```