### PR TITLE
network: Enable the RAs to fix IPv6 address assignment

### DIFF
--- a/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
+++ b/changelog/bugfixes/2022-01-14-enable-icmpv6-router-adverts.md
@@ -1,0 +1,1 @@
+- network: Enable the ICMPv6 RAs to fix IPv6 address assignment ([PR#51](https://github.com/flatcar-linux/init/pull/51))

--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -5,6 +5,7 @@ KernelCommandLine=!root
 [Network]
 DHCP=yes
 KeepConfiguration=dhcp-on-stop
+IPv6AcceptRA=true
 
 [DHCP]
 ClientIdentifier=mac

--- a/systemd/network/yy-vmware.network
+++ b/systemd/network/yy-vmware.network
@@ -4,6 +4,7 @@ Virtualization=vmware
 [Network]
 DHCP=yes
 KeepConfiguration=dhcp-on-stop
+IPv6AcceptRA=true
 
 [DHCP]
 UseMTU=true

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -1,6 +1,7 @@
 [Network]
 DHCP=yes
 KeepConfiguration=dhcp-on-stop
+IPv6AcceptRA=true
 
 [Match]
 Name=*


### PR DESCRIPTION
The IPv6 address are currently not automatically assigned due to the absence
of the IPv6AcceptRA configuration.

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>