### PR TITLE
configs/sshd_config: accept ssh-rsa in sshd_config for openssh 8.8

### DIFF
--- a/changelog/changes/2021-12-08-sshd-config-rsa.md
+++ b/changelog/changes/2021-12-08-sshd-config-rsa.md
@@ -1,0 +1,1 @@
+- Accept temporarily ssh-rsa in sshd_config for openssh 8.8 ([PR#54](https://github.com/flatcar-linux/init/pull/54))

--- a/configs/sshd_config
+++ b/configs/sshd_config
@@ -8,3 +8,8 @@ PrintMotd no # handled by PAM
 Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128-etm@openssh.com,umac-128@openssh.com
 KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+
+# Temporarily accept ssh-rsa algorithm for openssh >= 8.8,
+# until most ssh clients could deprecate ssh-rsa.
+HostkeyAlgorithms +ssh-rsa
+PubkeyAcceptedAlgorithms +ssh-rsa


### PR DESCRIPTION
Accept temporarily `ssh-rsa` algorithm in `sshd_config` for openssh >= 8.8, until most ssh clients could deprecate ssh-rsa.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
