### PR TITLE
networkd: prevent networkd interference with kubenet cbr0 interface

### DIFF
--- a/systemd/network/kubenet.network
+++ b/systemd/network/kubenet.network
@@ -1,0 +1,7 @@
+# Exclude Kubernetes Kubenet CNI bridge from DHCP by default
+
+[Match]
+Name=cbr0
+
+[Link]
+Unmanaged=yes


### PR DESCRIPTION
The Kubernetes Kubenet CNI bridge was getting the default networkd
configuration applied which tries to attach an IP address through DHCP.
This meant that the interface was stuck in this "configuring" state by
networkd and this is also a potential source of disruption as reported
in similar cases.

Set the cbr0 interface to be excluded from networkd (unmanaged) because
it is set up manually by kubenet and not through DHCP.

## How to use

## Testing done

I copied the new config to `/etc/systemd/network/cbr.network` and saw it take effect

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ will do in coreos-overlay