### PR TITLE
networkd: do not use DHCP for bridge devices

### DIFF
--- a/systemd/network/20-calico-vxlan.network
+++ b/systemd/network/20-calico-vxlan.network
@@ -1,0 +1,7 @@
+# Exclude calico vxlan devices from DHCP by default
+
+[Match]
+Name=vxlan.calico
+
+[Link]
+Unmanaged=yes

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -4,7 +4,8 @@ KeepConfiguration=dhcp-on-stop
 
 [Match]
 Name=*
-Type=!loopback
+Type=!loopback !dummy !bridge !tunnel !vxlan
+Driver=!veth
 
 [DHCP]
 UseMTU=true


### PR DESCRIPTION
The main change:

-    networkd: do not use DHCP for special devices
    
    We are always lagging behind with which interface names are used by
    CNIs and have to be set Unmanaged so that we don't use DHCP for them.
    
    Go the other way round and exclude special devices which won't use DHCP
    upfront so that we don't even try configuring them this way. Bridges
    normally don't get their IP address assinged via DHCP and if someone
    wants that, they are free to ship their own networkd unit. Same for
    tunnel devices and similar. If this causes problems, we can revert this
    because we still have the explicit rules but eventually this should
    allow us to retire some of our rules that match by interface name.

A drive-by fix which is still relevant in case we have revert the main change:

-    networkd: prevent networkd interference with calico vxlan interface
    
    The Calico vxlan interface was getting the default networkd
    configuration applied which tries to attach an IP address through DHCP.
    This meant that the interface was stuck in this "configuring" state by
    networkd and this is also a potential source of disruption as reported
    in similar cases.
    
    Set the vxlan.calico interface to be excluded from networkd (unmanaged)
    because it is set up manually by Calico and not through DHCP.


## How to use


## Testing done

