### PR TITLE
configs/tmpfiles.d: ensure /run/xtables.lock exists

### DIFF
--- a/configs/tmpfiles.d/xtables-lock.conf
+++ b/configs/tmpfiles.d/xtables-lock.conf
@@ -1,0 +1,4 @@
+# This file gets still created by iptables-legacy but since
+# iptables-nft is used now by default it doesn't but some containers
+# still have to bind mount it for legacy iptables operations.
+f       /run/xtables.lock       0600    -    -    -       -


### PR DESCRIPTION
The nftables update which included using the nftables compat backend
for the iptables binaries instead of xtables on the host resulted in
the lock file not being created anymore automatically. The lock file is
still required because the xtables backend doesn't go away and is used
by containers and, possibly, by invoking the legacy binaries on the
host (we ship them for easy access to the xtables lists).

Use a systemd-tmpfile directive to create the xtables lock file which,
e.g., gets bind-mounted to containers for coordination of xtables
modifications.


## How to use

Fixes https://github.com/flatcar-linux/Flatcar/issues/578

## Testing done

File got created at bootup in a VM. After file deletion the same file got created again by `iptables-legacy -L`

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ in coreos-overlay