### PR TITLE
bin/flatcar-update: don't assume $USER is set up, only use $EUID

### DIFF
--- a/bin/flatcar-update
+++ b/bin/flatcar-update
@@ -90,7 +90,7 @@ if [ -d "/etc/coreos" ]; then
   ln -s flatcar /etc/coreos
 fi
 
-HARDCODED_GROUP=$(grep -m 1 -o '^GROUP=.*' /etc/flatcar/update.conf || true)
+HARDCODED_GROUP=$(grep -m 1 -o '^GROUP=.*' /etc/flatcar/update.conf 2> /dev/null || true)
 if [ "${HARDCODED_GROUP}" != "" ]; then
   echo "Warning: found hardcoded ${HARDCODED_GROUP} in /etc/flatcar/update.conf - make sure it fits the release channel you want to follow" > /dev/stderr
 fi

--- a/bin/flatcar-update
+++ b/bin/flatcar-update
@@ -71,7 +71,7 @@ if [ "${FORCE_DEV_KEY}" = "1" ] && [ "${FORCE_FLATCAR_KEY}" = "1" ]; then
   echo "Error: must only specify one of --force-dev-key or --force-flatcar-key" > /dev/stderr ; exit 1
 fi
 
-[ "$USER" = "root" ] || { echo "Need to be root: sudo $0 $opts" > /dev/stderr ; exit 1 ; }
+[ "$EUID" = "0" ] || { echo "Need to be root: sudo $0 $opts" > /dev/stderr ; exit 1 ; }
 
 if mount | grep -q /usr/share/update_engine/update-payload-key.pub.pem; then
   echo "Warning: found a bind mount on /usr/share/update_engine/update-payload-key.pub.pem (will only unmount it if --force-dev-key|--force-flatcar-key is set)"


### PR DESCRIPTION
- bin/flatcar-update: don't assume $USER is set up, only use $EUID
  In some shells the USER variable does not get set up in the
    environment, causing the script to fail unless it is wrapped in
    a sudo call again to set the USER variable.
    Rely only on bash's EUID variable instead for the permission check.
- bin/flatcar-update: silence output on missing /etc/flatcar/update.conf
    The update.conf under /etc/flatcar does not really need to exist but
    grep's error message found its way into the script output.
    Silence the grep error message since it's ok when the file is missing.

## How to use

When merging, bump coreos-overlay commit ID

## Testing done

Ran the script and checked that it detects running as root or not, and doesn't print the warning anymore

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ will do in coreos-overlay under bugfixes:
```
- flatcar-update: Stopped checking for the `USER` environment variable which may not be set in all environments, causing the script to fail unless a workaround was used like prepending an additional `sudo` invocation ([PR#58](https://github.com/flatcar-linux/init/pull/58))
```
