### PR TITLE
systemd/system: add oem cloud init service

### DIFF
--- a/systemd/system/enable-oem-cloudinit.service
+++ b/systemd/system/enable-oem-cloudinit.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Enable cloudinit
+
+[Service]
+Type=oneshot
+StandardInput=file:/etc/.ignition-result.json
+ExecCondition=/usr/bin/jq -e '.userConfigProvided == false'
+ExecCondition=/usr/bin/jq -e '.provisioningBootID | gsub(\"-\"; \"\") | . == $id' --arg id %b
+ExecStart=/usr/bin/systemctl enable --now oem-cloudinit.service
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/system/multi-user.target.wants/enable-oem-cloudinit.service
+++ b/systemd/system/multi-user.target.wants/enable-oem-cloudinit.service
@@ -1,0 +1,1 @@
+../enable-oem-cloudinit.service

--- a/systemd/system/oem-cloudinit.service
+++ b/systemd/system/oem-cloudinit.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run cloudinit
+
+[Service]
+EnvironmentFile=/var/run/ignition.env
+Type=oneshot
+ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gce rackspace-onmetal azure cloudsigma packet vmware digitalocean); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
+ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws ]; then echo ec2-compat; else echo "${OEM_ID}" ; fi)"'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
these services, based on the ignition execution result will enable or
not cloudinit based on OEM.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

With ignition 3, there is no more "default" configuration (`default.ign`) on each OEM partition. So we need to add a mechanism to conditionally start cloudinit on the supported OEM.

This mechanism is based on the values of the `/etc/.ignition-result.json` result file produced by IgnitionV3.

Tested through: https://github.com/flatcar-linux/coreos-overlay/pull/1249


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
