### PR TITLE
systemd: disable foreign route management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,14 @@ install:
 	install -m 755 bin/* $(DESTDIR)/usr/bin
 	ln -sf flatcar-install $(DESTDIR)/usr/bin/coreos-install
 	install -m 755 scripts/* $(DESTDIR)/usr/lib/flatcar
-	install -m 644 systemd/network/* $(DESTDIR)/usr/lib/systemd/network
-	install -m 755 systemd/system-generators/* \
-		$(DESTDIR)/usr/lib/systemd/system-generators
 	install -m 644 udev/rules.d/* $(DESTDIR)/lib/udev/rules.d
 	install -m 755 udev/bin/* $(DESTDIR)/lib/udev
 	install -m 644 configs/editor.sh $(DESTDIR)/etc/env.d/99editor
 	install -m 600 configs/sshd_config $(DESTDIR)/usr/share/ssh/
 	install -m 644 configs/ssh_config $(DESTDIR)/usr/share/ssh/
 	install -m 644 configs/tmpfiles.d/* $(DESTDIR)/usr/lib/tmpfiles.d/
-	cp -a systemd/system/* $(DESTDIR)/usr/lib/systemd/system
+	cp -a systemd/* $(DESTDIR)/usr/lib/systemd/
+	chmod 755 $(DESTDIR)/usr/lib/systemd/system-generators/*
 	ln -sf ../run/issue $(DESTDIR)/etc/issue
 	ln -sf flatcar $(DESTDIR)/usr/lib/coreos
 	ln -sf flatcar $(DESTDIR)/usr/share/coreos

--- a/systemd/networkd.conf.d/10-disable-route-mgmt.conf
+++ b/systemd/networkd.conf.d/10-disable-route-mgmt.conf
@@ -1,0 +1,3 @@
+[Network]
+ManageForeignRoutes=no
+ManageForeignRoutingPolicyRules=no

--- a/systemd/resolved.conf.d/10-disable-dnssec.conf
+++ b/systemd/resolved.conf.d/10-disable-dnssec.conf
@@ -1,0 +1,2 @@
+[Resolve]
+DNSSEC=false

--- a/systemd/resolved.conf.d/10-disable-llmnr.conf
+++ b/systemd/resolved.conf.d/10-disable-llmnr.conf
@@ -1,0 +1,2 @@
+[Resolve]
+LLMNR=false


### PR DESCRIPTION
- systemd: disable foreign route management
    
    While systemd-networkd follows the principle of a declarative network
    configuration and thus needs a way to ensure that unwanted routes or
    routing policy rules get discarded, the interfacing with procedural
    network management from CNIs like Cilium is limited, so that when the
    interface is set to "unmanaged" through a networkd unit, any routing
    policies there would also be ignored and discarded unless they would
    be defined for a new unit for a dummy network interface. This means
    the only option left is to disable the discarding of foreign rules
    globally.
    
    Set the default for ManageForeignRoutes and
    ManageForeignRoutingPolicyRules to "no" to ensure that we don't
    interfere with the network management of the CNIs. Users that rely on
    the setting can still enable it again but only through a drop-in
    under /etc/systemd/networkd.conf.d/ because this here is a drop-in
    already that takes precedence over the top config file.
    
    See https://github.com/cilium/cilium/issues/18706
    and https://github.com/flatcar-linux/Flatcar/issues/620
    Replaces https://github.com/flatcar-linux/coreos-overlay/pull/1622

- systemd: move files to init repo as unified location
    
    The systemd drop-in files should only be in one repository, and using
    init is better than baselayout for that (baselayout is also used for
    the SDK).


## How to use

Together with baselayout PR

## Testing done

See coreos-overlay PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ TODO in coreos-overlay