### PR TITLE
add init.wrapper to force switch to legacy cgroups after initramfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install:
 	install -m 755 -d \
 		$(DESTDIR)/lib/udev/rules.d \
 		$(DESTDIR)/usr/bin \
+		$(DESTDIR)/usr/sbin \
 		$(DESTDIR)/usr/lib/flatcar \
 		$(DESTDIR)/usr/lib/systemd/system \
 		$(DESTDIR)/usr/lib/systemd/network \
@@ -22,6 +23,7 @@ install:
 		$(DESTDIR)/etc/env.d \
 		$(DESTDIR)/usr/share/ssh
 	install -m 755 bin/* $(DESTDIR)/usr/bin
+	install -m 755 sbin/* $(DESTDIR)/usr/sbin
 	ln -sf flatcar-install $(DESTDIR)/usr/bin/coreos-install
 	install -m 755 scripts/* $(DESTDIR)/usr/lib/flatcar
 	install -m 644 udev/rules.d/* $(DESTDIR)/lib/udev/rules.d

--- a/sbin/init.wrapper
+++ b/sbin/init.wrapper
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "(flatcar) runtime switch to legacy cgroups"
+
+CTRL_FILE=/sys/fs/cgroup/cgroup.subtree_control
+if [[ -f "${CTRL_FILE}" ]]; then
+  find /sys/fs/cgroup -type d -delete 2>/dev/null
+  while read ctrl; do
+    echo "-${ctrl}" >"${CTRL_FILE}"
+  done <"${CTRL_FILE}"
+fi
+umount /sys/fs/cgroup
+
+mkdir -p /tmp
+read cmdline </proc/cmdline
+printf "%s %s\n" "$cmdline" "systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=1" >/tmp/cmdline
+chmod 0444 /tmp/cmdline
+mount -o bind,ro -t none /tmp/cmdline /proc/cmdline
+rm /tmp/cmdline
+
+init=$(readlink -f /usr/sbin/init)
+exec $init --switched-root --system


### PR DESCRIPTION
# add init.wrapper to force switch to legacy cgroups after initramfs

init.wrapper attempts to disable cgroup controllers, unmount cgroup2,
and then inject (using a bind mount) additional kernel command line
arguments. These kernel parameters are used by systemd to proceed to
mount legacy cygroups.

## How to use

To be used with https://github.com/flatcar-linux/bootengine/pull/35

## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
