### PR TITLE
sbin/init.wrapper: remove processes from subcgroups before deleting

### DIFF
--- a/sbin/init.wrapper
+++ b/sbin/init.wrapper
@@ -4,10 +4,25 @@ echo "(flatcar) runtime switch to legacy cgroups"
 
 CTRL_FILE=/sys/fs/cgroup/cgroup.subtree_control
 if [[ -f "${CTRL_FILE}" ]]; then
-  find /sys/fs/cgroup -type d -delete 2>/dev/null
+  find /sys/fs/cgroup/*/ -name cgroup.procs -exec grep . {} \; | \
+  while read pid; do
+    echo "$pid" >/sys/fs/cgroup/cgroup.procs 2>/dev/null
+  done
+  find /sys/fs/cgroup/*/ -type d -delete 2>/dev/null
+  dump=0
   while read ctrl; do
-    echo "-${ctrl}" >"${CTRL_FILE}"
+    if ! echo "-${ctrl}" >"${CTRL_FILE}" ; then
+      dump=1
+    fi
   done <"${CTRL_FILE}"
+  if [[ "${dump}" -eq  1 ]]; then
+    echo "failed to unbind controllers; debug dump"
+    echo "---"
+    ps faux
+    find  /sys/fs/cgroup/ -name pids.current -exec grep -Hn . {} \;
+    find  /sys/fs/cgroup/ -name cgroup.procs -exec grep -Hn . {} \;
+    echo "---"
+  fi
 fi
 umount /sys/fs/cgroup
 


### PR DESCRIPTION
# sbin/init.wrapper: remove processes from subcgroups before deleting

In an attempt to prevent the cgroup from being busy when we unbind controllers
from it.

Will be cherry-picked to flatcar-3139.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5007/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
