### PR TITLE
systemd/system: convert "gcp" OEM to "gce"

### DIFF
--- a/systemd/system/oem-cloudinit.service
+++ b/systemd/system/oem-cloudinit.service
@@ -4,8 +4,8 @@ Description=Run cloudinit
 [Service]
 EnvironmentFile=/var/run/ignition.env
 Type=oneshot
-ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gce rackspace-onmetal azure cloudsigma packet vmware digitalocean); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
-ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws ]; then echo ec2-compat; else echo "${OEM_ID}" ; fi)"'
+ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gcp rackspace-onmetal azure cloudsigma packet vmware digitalocean); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
+ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws ]; then echo ec2-compat; elif [ "${OEM_ID}" = gcp ]; then echo gce; else echo "${OEM_ID}" ; fi)"'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
to be compatible with ignition, earlier in the boot gce is converted to
gcp. So we need to translate back gcp to gce to be compatible with
cloudinit.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
