### PR TITLE
systemd/system: run update-ssh-keys once after Ignition

### DIFF
--- a/systemd/system/multi-user.target.wants/update-ssh-keys-after-ignition.service
+++ b/systemd/system/multi-user.target.wants/update-ssh-keys-after-ignition.service
@@ -1,0 +1,1 @@
+../update-ssh-keys-after-ignition.service

--- a/systemd/system/update-ssh-keys-after-ignition.service
+++ b/systemd/system/update-ssh-keys-after-ignition.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run update-ssh-keys once after Ignition
+
+[Service]
+Type=oneshot
+StandardInput=file:/etc/.ignition-result.json
+ExecCondition=/usr/bin/jq -e '.userConfigProvided == true'
+ExecCondition=/usr/bin/jq -e '.provisioningBootID | gsub(\"-\"; \"\") | . == $id' --arg id %b
+ExecStart=/bin/bash -c 'ret=0; for nameandhomedir in $(cut -d : -f 1,6 /etc/passwd); do name=$(echo "$nameandhomedir"| cut -d : -f 1); homedir=$(echo "$nameandhomedir"| cut -d : -f 2); if [ -d "$homedir"/.ssh/authorized_keys.d ]; then update-ssh-keys -u "$name" || ret=1; fi; done; exit $ret'
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The new Ignition version dropped support for creating the
authorized_keys file alongside the authorized_keys.d entry and can only
write one of them.
Call update-ssh-keys once after Ignition ran, for each user that has
the authorized_keys.d folder.

Fixes https://github.com/flatcar-linux/Flatcar/issues/699


## How to use

Test with distro.writeAuthorizedKeysFragment set to the defaul when compiling Ignition

## Testing done

Tested the new unit on a VM that booted with keys from Ignition

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ in coreos-overlay