### PR TITLE
systemd/network: apply gce naming rules to GVE interfaces as well

### DIFF
--- a/systemd/network/98-gce-coreos-virtio.link
+++ b/systemd/network/98-gce-coreos-virtio.link
@@ -4,7 +4,7 @@
 # The old name ens4v1 was hardcoded in a udev rule which did not
 # work anymore.
 [Match]
-Driver=virtio_net
+Driver=virtio_net gve
 KernelCommandLine=coreos.oem.id=gce
 [Link]
 NamePolicy=kernel database onboard

--- a/systemd/network/98-gce-virtio.link
+++ b/systemd/network/98-gce-virtio.link
@@ -4,7 +4,7 @@
 # The old name ens4v1 was hardcoded in a udev rule which did not
 # work anymore.
 [Match]
-Driver=virtio_net
+Driver=virtio_net gve
 KernelCommandLine=flatcar.oem.id=gce
 [Link]
 NamePolicy=kernel database onboard


### PR DESCRIPTION
GCP introduced a new network interface type which uses the gve driver.
Add it to the link file so that gve interfaces get the same predictable
naming as virtio-net interfaces.