### PR TITLE
systemd/system/ensure-sysext: skip unit if systemd-sysext is skipped

### DIFF
--- a/systemd/system/ensure-sysext.service
+++ b/systemd/system/ensure-sysext.service
@@ -2,6 +2,12 @@
 BindsTo=systemd-sysext.service
 After=systemd-sysext.service
 DefaultDependencies=no
+# Keep in sync with systemd-sysext.service
+ConditionDirectoryNotEmpty=|/etc/extensions
+ConditionDirectoryNotEmpty=|/run/extensions
+ConditionDirectoryNotEmpty=|/var/lib/extensions
+ConditionDirectoryNotEmpty=|/usr/local/lib/extensions
+ConditionDirectoryNotEmpty=|/usr/lib/extensions
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
The unit failed to execute when the dependency systemd-sysext.service
was skipped because it's not needed. Normally this is harmless but it
still triggers a OnFailure event as reported in
https://github.com/flatcar-linux/Flatcar/issues/710

Use the same logic for skipping execution as done in
systemd-sysext.service - we can't use "systemctl is-enabled" because
Flatcar's inbuilt unit symlinks are not reported as "enabled".


## How to use

Test that the built image doesn't contain a log about the unit having failed because of a dependency not being run

## Testing done

Works as expected: `ensure-sysext.service was skipped because all trigger condition checks failed`

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ TODO in coreos-overlay