### PR TITLE
systemd-sysext.service.d: add drop-in for OEM partition mount actions

### DIFF
--- a/systemd/system/systemd-sysext.service.d/10-mount-oem-partition.conf
+++ b/systemd/system/systemd-sysext.service.d/10-mount-oem-partition.conf
@@ -1,0 +1,14 @@
+# Systemd-sysext removes all mounts under /usr and we need to restore the OEM partition mount.
+# Note: This does not cover the rare case of a user-supplied OEM tmpfs for PXE boots,
+#       the user needs to copy the files from the OEM partition to the rootfs via Ignition
+#       or embed them into Ignition.
+#       In the future we can try to move the OEM mount point under /mnt or /run and have
+#       /usr/share/oem be a symlink to it.
+[Unit]
+# Needed for oem-gce-enable-oslogin.service at the moment but as a precaution also done for others in case these get changed to start earlier
+# (from coreos-overlay:coreos-base/oem-*/files/units/*service)
+Before=oem-gce-enable-oslogin.service oem-gce.service waagent.service amazon-ssm-agent.service vmtoolsd.service nvidia.service
+[Service]
+ExecStartPre=/usr/bin/systemctl stop usr-share-oem.mount
+ExecStartPost=/usr/bin/systemctl start usr-share-oem.mount
+ExecStopPost=/usr/bin/systemctl start usr-share-oem.mount

--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -14,3 +14,4 @@ What=/dev/disk/by-label/OEM
 Where=/usr/share/oem
 Options=nodev
 Type=auto
+LazyUnmount=yes


### PR DESCRIPTION
When systemd-sysext sets up the new /usr mount, the OEM partition
remains mounted but the mount point is not visible anymore. This breaks
access to grub.cfg, oem-release, and any OEM tools.
Add a drop-in for the systemd-sysext service to first unmount the OEM
partition to prevent stale mounts from piling up that cause the
usr-share-oem.mount unit to fail on stop, and then mount the OEM
partition again when systemd-sysext did its work. At the moment a
"ExecStopPre" action does not exist in systemd and luckily is not
needed because systemd-sysext removes the OEM mount together with the
overlay mounts.  The lazy unmount makes it possible to unmount while a
    process from the OEM tools is running.


## How to use

Check whether the OEM remount interferes with the OEM tool startup

## Testing done

Manually restarted systemd-sysext on Azure (process kept running), on GCE (couldn't test because GCE is broken at the moment, see Jeremi's PRs for the fix) and on VMware ESX (process kept running). The remount on boot was finished before the OEM services started.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ TODO in c-o