### PR TITLE
config: add kubernetes configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ install:
 		$(DESTDIR)/usr/lib/systemd/system-generators \
 		$(DESTDIR)/usr/lib/tmpfiles.d \
 		$(DESTDIR)/etc/env.d \
-		$(DESTDIR)/usr/share/ssh
+		$(DESTDIR)/usr/share/ssh \
+		$(DESTDIR)/usr/lib/modules-load.d
 	install -m 755 bin/* $(DESTDIR)/usr/bin
 	install -m 755 sbin/* $(DESTDIR)/usr/sbin
 	ln -sf flatcar-install $(DESTDIR)/usr/bin/coreos-install
@@ -29,6 +30,7 @@ install:
 	install -m 644 udev/rules.d/* $(DESTDIR)/lib/udev/rules.d
 	install -m 755 udev/bin/* $(DESTDIR)/lib/udev
 	install -m 644 configs/editor.sh $(DESTDIR)/etc/env.d/99editor
+	install -m 644 configs/modules-load.d/* $(DESTDIR)/usr/lib/modules-load.d/
 	install -m 600 configs/sshd_config $(DESTDIR)/usr/share/ssh/
 	install -m 644 configs/ssh_config $(DESTDIR)/usr/share/ssh/
 	install -m 644 configs/tmpfiles.d/* $(DESTDIR)/usr/lib/tmpfiles.d/

--- a/configs/modules-load.d/k8s.conf
+++ b/configs/modules-load.d/k8s.conf
@@ -1,0 +1,2 @@
+overlay
+br_netfilter


### PR DESCRIPTION
With Kubernetes 1.24 the dockershim component has been removed from the kubelet.
Docker was automatically loading the `br_netfilter` module so we need to
load the module automatically with `systemd-modules-load`.

See also: https://kubernetes.io/docs/setup/production-environment/container-runtimes/#forwarding-ipv4-and-letting-iptables-see-bridged-traffic

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>