### PR TITLE
systemd/sysinit: add "delete-config" service

### DIFF
--- a/systemd/system/ignition-delete-config.service
+++ b/systemd/system/ignition-delete-config.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Ignition (delete config)
+Documentation=https://coreos.github.io/ignition/
+
+ConditionFirstBoot=true
+ConditionPathExists=/run/ignition.env
+ConditionKernelCommandLine=|ignition.platform.id=virtualbox
+ConditionKernelCommandLine=|flatcar.oem.id=virtualbox
+ConditionKernelCommandLine=|coreos.oem.id=virtualbox
+ConditionKernelCommandLine=|ignition.platform.id=vmware
+ConditionKernelCommandLine=|flatcar.oem.id=vmware
+ConditionKernelCommandLine=|coreos.oem.id=vmware
+
+DefaultDependencies=no
+# Run before any user services to prevent potential config leaks
+Before=sysinit.target
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+EnvironmentFile=/run/ignition.env
+StandardInput=file:/etc/.ignition-result.json
+ExecCondition=/usr/bin/jq -e '.userConfigProvided == true'
+ExecCondition=/usr/bin/jq -e '.provisioningBootID | gsub(\"-\"; \"\") | . == $id' --arg id %b
+ExecStart=/usr/libexec/ignition-rmcfg --platform=${PLATFORM_ID}
+RemainAfterExit=yes
+
+[Install]
+# Not RequiredBy, since we want to allow the unit to be masked
+WantedBy=sysinit.target

--- a/systemd/system/sysinit.target.wants/ignition-delete-config.service
+++ b/systemd/system/sysinit.target.wants/ignition-delete-config.service
@@ -1,0 +1,1 @@
+../ignition-delete-config.service


### PR DESCRIPTION
this service removes config from VMWare and Virtualbox.

Since "cloudinit" relies on the userdata fields too, we need to prevent
the userdata deletion if the configuration is different from an ignition
one.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

To be merged with: https://github.com/flatcar-linux/coreos-overlay/pull/1948

