### PR TITLE
systemd/system: enable cloudinit for openstack

### DIFF
--- a/systemd/system/oem-cloudinit.service
+++ b/systemd/system/oem-cloudinit.service
@@ -4,8 +4,8 @@ Description=Run cloudinit
 [Service]
 EnvironmentFile=/var/run/ignition.env
 Type=oneshot
-ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gcp rackspace-onmetal azure cloudsigma packet vmware digitalocean); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
-ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws ]; then echo ec2-compat; elif [ "${OEM_ID}" = gcp ]; then echo gce; else echo "${OEM_ID}" ; fi)"'
+ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gcp rackspace-onmetal azure cloudsigma packet vmware digitalocean openstack); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
+ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws -o "${OEM_ID}" = openstack ]; then echo ec2-compat; elif [ "${OEM_ID}" = gcp ]; then echo gce; else echo "${OEM_ID}" ; fi)"'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Allow oem-cloudinit.service for openstack too

Fixes https://github.com/flatcar-linux/Flatcar/issues/817, an issue where ssh keys were not fetched if no user-data
was provisioned, but only a keypair.

## How to use

This patch should make sure that a Flatcar-based OpenStack VM can be connected to with ssh if the public key is configured via the key_name server property and not as part of ignite user-data.

## Testing done

none

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
