### PR TITLE
zz-default: fix unmanaged type

### DIFF
--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -5,7 +5,7 @@ IPv6AcceptRA=true
 
 [Match]
 Name=*
-Type=!loopback !dummy !bridge !tunnel !vxlan !wireguard
+Type=!loopback dummy bridge tunnel vxlan wireguard
 Driver=!veth
 
 [DHCP]


### PR DESCRIPTION
wireguard is still being managed while it should not. Reading the
documentation[^1]:

> If the list is prefixed with a "!", the test is inverted.

[^1]: https://systemd.network/systemd.network.html#Type=

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>