### PR TITLE
systemd/network/vmware: sync with zz-default

### DIFF
--- a/systemd/network/yy-vmware.network
+++ b/systemd/network/yy-vmware.network
@@ -1,5 +1,7 @@
 [Match]
 Virtualization=vmware
+Type=!loopback dummy bridge tunnel vxlan wireguard
+Driver=!veth
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6380/cldsv/

SSHed on a VMWare instance to see the wireguard links unmanaged.

Related PR: https://github.com/flatcar-linux/mantle/pull/361