### PR TITLE
motd: Update the motd to notify about the deprecating LTS-2021

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -23,3 +23,8 @@ if [[ "${GROUP}" = "lts" ]] && [[ "${SERVER}" = "https://public.update.flatcar-l
 	echo "use GROUP=lts-STREAM or your own update server with a managed 'lts' group to stick to one stream (e.g., 2021) and opt-out of automatic major version updates." >> /run/flatcar/motd
 	echo "Read more: https://www.flatcar.org/docs/latest/setup/releases/switching-channels/#freezing-an-lts-stream" >> /run/flatcar/motd
 fi
+
+if [[ "${GROUP}" = "lts" ]] && [[ "${VERSION}" == 2605* ]]; then
+	echo "The LTS stream, LTS-2021 is now deprecated. Please update to a newer LTS stream for updates." >> /run/flatcar/motd
+	echo "Read more: https://flatcar-linux.org/docs/latest/setup/releases/switching-channels/" >> /run/flatcar/motd
+fi

--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -24,7 +24,5 @@ if [[ "${GROUP}" = "lts" ]] && [[ "${SERVER}" = "https://public.update.flatcar-l
 	echo "Read more: https://www.flatcar.org/docs/latest/setup/releases/switching-channels/#freezing-an-lts-stream" >> /run/flatcar/motd
 fi
 
-if [[ "${GROUP}" = "lts" ]] && [[ "${VERSION}" == 2605* ]]; then
-	echo "The LTS stream, LTS-2021 is now deprecated. Please update to a newer LTS stream for updates." >> /run/flatcar/motd
-	echo "Read more: https://flatcar-linux.org/docs/latest/setup/releases/switching-channels/" >> /run/flatcar/motd
-fi
+echo "The LTS stream LTS-2021 is now deprecated. Please update to a newer LTS stream for updates." >> /run/flatcar/motd
+echo "Read more: https://flatcar-linux.org/docs/latest/setup/releases/switching-channels/" >> /run/flatcar/motd


### PR DESCRIPTION
# motd: Update the motd to notify about the deprecating LTS-2021

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

## Testing done

Jenkins CI Running. http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/327/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
