### PR TITLE
Fix comments in sshd config

### DIFF
--- a/configs/sshd_config
+++ b/configs/sshd_config
@@ -3,8 +3,10 @@ Subsystem sftp internal-sftp
 ClientAliveInterval 180
 UseDNS no
 UsePAM yes
-PrintLastLog no # handled by PAM
-PrintMotd no # handled by PAM
+# handled by PAM
+PrintLastLog no
+# handled by PAM
+PrintMotd no
 Ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
 MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128-etm@openssh.com,umac-128@openssh.com
 KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256


### PR DESCRIPTION
According to sshd_config manual, only lines starting with a hash and empty lines are treated as comments. Which means that comments coming after the key value pairs are not really comments and sshd complains about them like:

```
/etc/ssh/sshd_config line 6: keyword PrintLastLog extra arguments at end of line
/etc/ssh/sshd_config line 7: keyword PrintMotd extra arguments at end of line
/etc/ssh/sshd_config: terminating, 2 bad configuration options
```
