### PR TITLE
Skip execution of the first boot services if Ignition did not run

### DIFF
--- a/systemd/system/enable-oem-cloudinit.service
+++ b/systemd/system/enable-oem-cloudinit.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Enable cloudinit
+ConditionPathExists=/etc/.ignition-result.json
 
 [Service]
 Type=oneshot

--- a/systemd/system/update-ssh-keys-after-ignition.service
+++ b/systemd/system/update-ssh-keys-after-ignition.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Run update-ssh-keys once after Ignition
+ConditionPathExists=/etc/.ignition-result.json
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The evaluation of the service that enables coreos-cloudinit if Ignition found no Ignition configuration, and the service that processes the Ignition-provided SSH keys, both rely on Ignition to run on first boot. If Ignition didn't run, they fail to evaluate their conditions.

Skip the services if Ignition didn't run. This makes the two failures disappear but also means that we define now that coreos-cloudinit will only run if Ignition had its chance to create its flag file, otherwise we will not enable coreos-cloudinit. This was the behavior already but it wasn't really covered explicitly and the failure could look like a bug. Since coreos-cloudinit is the fallback if no Ignition config was provided it would make sense to enable it if Ignition didn't run but actually we want Ignition to run first to see if the user data is Ignition or not, and if Ignition didn't run it means that we are not a first boot, thus we shouldn't really enable coreos-cloudinit either. So in summary, this is an aesthetic change that hides the failure messages in the boot log if, e.g., a PXE boot is done without the first boot flag.

## How to use


## Testing done

On a VM I ran `sudo systemctl edit SERVICE` for both service units and added the `[Unit]\nCondition…` entries there, then deleted the `/etc/.ignition-result.json` file and rebooted. Now the services where skipped nicely, before they had not only the status `condition failed` but also red output `Failed to set up standard input: No such file or directory` and `Failed at step STDIN spawning /usr/bin/jq: No such file or directory`.

No changelog required I would say.