### PR TITLE
If the directory symlink exists, don't create a symlink in it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ install:
 	cp -a systemd/* $(DESTDIR)/usr/lib/systemd/
 	chmod 755 $(DESTDIR)/usr/lib/systemd/system-generators/*
 	ln -sf ../run/issue $(DESTDIR)/etc/issue
-	ln -sf flatcar $(DESTDIR)/usr/lib/coreos
-	ln -sf flatcar $(DESTDIR)/usr/share/coreos
+	ln -sfT flatcar $(DESTDIR)/usr/lib/coreos
+	ln -sfT flatcar $(DESTDIR)/usr/share/coreos
 
 install-usr: install
 

--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -11,7 +11,7 @@
 source /usr/lib/os-release
 
 mkdir -p /run/flatcar
-ln -sf flatcar /run/coreos
+ln -sfT flatcar /run/coreos
 OEM=""
 if [ -f /usr/share/oem/oem-release ]; then
   OEM="$(source /usr/share/oem/oem-release; echo " for $NAME")"


### PR DESCRIPTION
When motdgen ran again, we ended up with a "flatcar -> flatcar" symlink inside the /run/flatcar/ directory because the existing /run/coreos symlink is pointing to the /run/flatcar directory and without -T ln will then create the symlink inside the given path instead of overwriting the symlink.
Add the -T flag and also use it in the Makefile whenenver we want to set up symlinks for directories.

## How to use

It's not a bug that makes problems, no backport needed.

## Testing done

Ran the new `motdgen` version here with `sudo` and it didn't create the wrong `/run/flatcar/flatcar` symlink anymore while `sudo /usr/lib/flatcar/motdgen` did.
