### PR TITLE
systemd/network: Fix dummy interface exclusion rule in default networkd unit

### DIFF
--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -5,8 +5,8 @@ IPv6AcceptRA=true
 
 [Match]
 Name=*
-Type=!loopback dummy bridge tunnel vxlan wireguard
-Driver=!veth
+Type=!loopback bridge tunnel vxlan wireguard
+Driver=!veth dummy
 
 [DHCP]
 UseMTU=true


### PR DESCRIPTION
The default networkd unit should not apply to all devices, e.g., not to bridges, tunnels, dummy interfaces etc. However, for dummy interfaces the rule was wrong.
Fix the exclusion rule for dummy interfaces, which are not a type but a certain driver.


## How to use

## Testing done

Was tested by copying it to `/etc/systemd/network/` and doing `ip link add dummy0 type dummy` to create such an interface and `networkctl reload` to apply the unit change and see that the interface becomes unmanaged.
