### PR TITLE
Sync azure udev rules

### DIFF
--- a/udev/rules.d/66-azure-storage.rules
+++ b/udev/rules.d/66-azure-storage.rules
@@ -1,27 +1,34 @@
-ACTION=="add|change", SUBSYSTEM=="block", ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", GOTO="azure_disk"
-GOTO="azure_end"
+# Azure specific rules.
+ACTION!="add|change", GOTO="walinuxagent_end"
+SUBSYSTEM!="block", GOTO="walinuxagent_end"
+ATTRS{ID_VENDOR}!="Msft", GOTO="walinuxagent_end"
+ATTRS{ID_MODEL}!="Virtual_Disk", GOTO="walinuxagent_end"
 
-LABEL="azure_disk"
-# Root has a GUID of 0000 as the second value
-# The resource/resource has GUID of 0001 as the second value
-ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_names"
-ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_names"
-# Wellknown SCSI controllers
+# Match the known ID parts for root and resource disks.
+ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="wa_azure_names"
+ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="wa_azure_names"
+
+# Gen2 disk.
 ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
+# Create symlinks for data disks attached.
 ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi1", GOTO="azure_datadisk"
 ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi2", GOTO="azure_datadisk"
 ATTRS{device_id}=="{f8b3781d-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi3", GOTO="azure_datadisk"
-GOTO="azure_end"
+GOTO="walinuxagent_end"
 
-# Retrieve LUN number for datadisks
+# Parse out the fabric n ame based off of scsi indicators.
 LABEL="azure_datadisk"
-ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
-PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
-GOTO="azure_end"
+ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result"
+ENV{DEVTYPE}=="disk", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result"
 
-# Create the symlinks
-LABEL="azure_names"
-ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}", TAG+="systemd"
-ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n", TAG+="systemd"
+ENV{fabric_name}=="scsi0/lun0", ENV{fabric_name}="root"
+ENV{fabric_name}=="scsi0/lun1", ENV{fabric_name}="resource"
+# Don't create a symlink for the cd-rom.
+ENV{fabric_name}=="scsi0/lun2", GOTO="walinuxagent_end"
 
-LABEL="azure_end"
+# Create the symlinks.
+LABEL="wa_azure_names"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"
+
+LABEL="walinuxagent_end"

--- a/udev/rules.d/66-azure-storage.rules
+++ b/udev/rules.d/66-azure-storage.rules
@@ -28,7 +28,7 @@ ENV{fabric_name}=="scsi0/lun2", GOTO="walinuxagent_end"
 
 # Create the symlinks.
 LABEL="wa_azure_names"
-ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
-ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}", TAG+="systemd"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n", TAG+="systemd"
 
 LABEL="walinuxagent_end"

--- a/udev/rules.d/99-azure-product-uuid.rules
+++ b/udev/rules.d/99-azure-product-uuid.rules
@@ -1,6 +1,3 @@
-# This rule can be removed once this lands:
-# http://thread.gmane.org/gmane.linux.kernel/1960257
-
 SUBSYSTEM!="dmi", GOTO="product_uuid-exit"
 ATTR{sys_vendor}!="Microsoft Corporation", GOTO="product_uuid-exit"
 ATTR{product_name}!="Virtual Machine", GOTO="product_uuid-exit"


### PR DESCRIPTION
We preserve our modification that added systemd tags to storage devices.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1531/cldsv (as a part of sysext for azure oem)