### PR TITLE
flatcar-install: Wait for subproccesses and report errors

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -568,7 +568,9 @@ if [[ -n "${DRY_RUN}" ]]; then
     exit 0
 fi
 
-function is_modified() [[ -e "${WORKDIR}/disk_modified" ]]
+function is_modified() {
+    [[ -e "${WORKDIR}/disk_modified" ]]
+}
 
 _disk_status=
 function wait_for_disk() {

--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -573,14 +573,14 @@ function is_modified() {
 }
 
 _disk_status=
-function wait_for_disk() {
+function get_disk_status() {
     [ -n "${_disk_status}" ] ||
-    read -rt 7200 _disk_status <> "${WORKDIR}/disk_modified"
+    read -rt 0.1 _disk_status <> "${WORKDIR}/disk_modified" # Use a timeout of 100ms to behave like a non-blocking read
+    echo "${_disk_status}"
 }
 
 function write_to_disk() {
     mkfifo -m 0600 "${WORKDIR}/disk_modified"
-    trap '(exec 2>/dev/null ; echo done > "${WORKDIR}/disk_modified") &' RETURN
 
     # We are at the point of no return, so wipe disk labels missed below.
     # In particular, ZFS writes labels in the last half-MiB of the disk.
@@ -599,6 +599,8 @@ function write_to_disk() {
     done
     [ -z "$try" ] || exit 1
     udevadm settle
+    # Communicate success through FIFO when the caller can't act on the return code
+    (exec 2>/dev/null ; echo "done" > "${WORKDIR}/disk_modified") &
 }
 
 function install_from_file() {
@@ -704,6 +706,11 @@ function install_from_url() {
         [ ${EEND[2]} -ne 0 ] && echo "${EEND[2]}: GPG signature verification failed for ${IMAGE_NAME}" >&2
         exit 1
     fi 3> >(write_to_disk)
+    wait
+    if [ "$(get_disk_status)" != "done" ]; then
+      echo "write_to_disk: Failed writing image to disk" >&2
+      exit 1
+    fi
 }
 
 function write_cloudinit() {
@@ -773,7 +780,6 @@ else
     else
         install_from_url
     fi
-    wait_for_disk
     write_cloudinit
     write_ignition
     if [[ -n "${CREATE_UEFI}" ]]; then


### PR DESCRIPTION
- flatcar-install: Wait for subproccesses and report errors
    
    The redirection of FD 3 to the input FD with >(write_to_disk) causes
    the function to not wait or react on errors from write_to_disk.
    Before returning, wait for all subprocesses to finsh and then check the
    success through the out-of-band FIFO. Since we don't need the waiting
    with a large timeout anymore we can change the wait function to fulfill
    a new purpose.

- flatcar-install: Function syntax fixes for shellcheck
    
    While bash allows the function brackes to be missing, shellcheck
    doesn't.
    Add brackets to demark the function body.

## How to use


## Testing done

```
truncate -s 10G second_disk.img
./flatcar_production_qemu.sh -- -drive if=virtio,file="$PWD/second_disk.img"
```
Then `scp -r -C -P 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null bin/flatcar-install       core@127.0.0.1:` and `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 core@127.0.0.1` and in the VM:

```
sudo ./flatcar-install -s
```
This worked, then I inserted a `false` in `write_to_disk` (after the second `dd`) and reran `sudo ./flatcar-install -d /dev/vdb`.
It failed with "write_to_disk: Failed writing image to disk" as expected.
Before this change, it was reporting success even though `write_to_disk` failed (if the bash issue is absent which causes a timeout of 2 hours due to the trap not working which is another issue) .

Related to https://github.com/flatcar/Flatcar/issues/1059