### PR TITLE
udev: Use $name in issuegen rule

### DIFF
--- a/udev/rules.d/90-issuegen.rules
+++ b/udev/rules.d/90-issuegen.rules
@@ -1,2 +1,2 @@
-ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/flatcar/issuegen add $env{INTERFACE}"
-ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/flatcar/issuegen remove $env{INTERFACE}"
+ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/flatcar/issuegen add $name"
+ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/flatcar/issuegen remove $name"


### PR DESCRIPTION
# udev: Use $name in issuegen rule

A user is trying to rename network interfaces. This is working but the login issue file still has the initial network interface names. This appears to be similar to https://github.com/thkukuk/issue-generator/issues/6, fix it by using $name instead of $ENV{INTERACE}, so that the rule runs with a changed name.

## How to use

## Testing done

Ran a qemu vm with the following udev rules:
```
# cd /etc/udev/rules.d
# cat 60-net.rules
SUBSYSTEMS=="pci", ACTION=="add", DRIVERS=="?*", KERNELS=="0000:00:03.0", NAME="ge0"
# cat 90-issuegen.rules
ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/flatcar/issuegen add $name"
ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/flatcar/issuegen remove $name"
```

issue is correct:
```
This is localhost (Linux x86_64 6.1.37-flatcar) 12:40:59
SSH host key: SHA256:BLiSc209qqCjiSEAZ0HR3jskm9iluPTkHEFtcfL5qvE (ECDSA)
SSH host key: SHA256:P2B0BvpZjOdylo5auGGLOLqdpH51TpzKoB6hcgUc6v0 (RSA)
SSH host key: SHA256:6op7WJi6lY61NwhRkNoxWzNO+9bOHXiZ+PG3w+Gfpdc (ED25519)
ge0: 10.0.2.15 fec0::5054:ff:fe12:3456
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
