### PR TITLE
systemd/system: `upholds` does not respect conditions

### DIFF
--- a/systemd/system/sshkeys.service
+++ b/systemd/system/sshkeys.service
@@ -15,12 +15,10 @@ ConditionKernelCommandLine=|ignition.platform.id=gce
 ConditionKernelCommandLine=|flatcar.oem.id=gce
 ConditionKernelCommandLine=|coreos.oem.id=gce
 
-Upholds=coreos-metadata-sshkeys@core.service
-
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/true
+ExecStart=/usr/bin/systemctl start coreos-metadata-sshkeys@core.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
for example, it is always started on QEMU

---

Don't know if it's done on purpose or not but might be worth to at least double check the upstream documentation regarding this.