### PR TITLE
systemd/network: Ignore mana VFs on Azure

### DIFF
--- a/systemd/network/yy-azure-sriov-coreos.network
+++ b/systemd/network/yy-azure-sriov-coreos.network
@@ -9,7 +9,7 @@ KernelCommandLine=coreos.oem.id=azure
 # VF driver currently used in Azure. If other drivers come into use, the
 # symptom will be a VF interface in the output of "networkctl" which never
 # finishes configuring.
-Driver=mlx4_en mlx5_core
+Driver=mlx4_en mlx5_core mana
 
 [Link]
 Unmanaged=yes

--- a/systemd/network/yy-azure-sriov.network
+++ b/systemd/network/yy-azure-sriov.network
@@ -9,7 +9,7 @@ KernelCommandLine=flatcar.oem.id=azure
 # VF driver currently used in Azure. If other drivers come into use, the
 # symptom will be a VF interface in the output of "networkctl" which never
 # finishes configuring.
-Driver=mlx4_en mlx5_core
+Driver=mlx4_en mlx5_core mana
 
 [Link]
 Unmanaged=yes


### PR DESCRIPTION
# Ignore mana VFs on Azure

Azure is introducing a new generation of NICs, that are architected the same way as the current Mellanox based ones: there is a synthetic (vmbus) NIC for handling some control traffic (including DHCP) and a VF that is enslaved to the synthetic NIC. We therefore need to exclude the devices manage by the mana driver from IP management.


## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

No testing, just got a LISA bugreport.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
