### PR TITLE
flatcar-update: Provide hash_sha256 attribute for OEM packages

### DIFF
--- a/bin/flatcar-update
+++ b/bin/flatcar-update
@@ -222,13 +222,17 @@ for DOWNLOAD_FILE in "$PAYLOAD" "${EXTENSIONS[@]}"; do
   SIZE=$(stat -L --printf='%s\n' "${DOWNLOAD_FILE}")
   BASEFILENAME="$(basename -- "${DOWNLOAD_FILE}" | sed 's/flatcar_test_update-//g')"
   REQUIRED="false"
+  OPTHASH256=""
   if [ "${DOWNLOAD_FILE}" = "${PAYLOAD}" ]; then
     # In case a local payload is given we have to use the correct name
     BASEFILENAME="flatcar_production_update.gz"
     REQUIRED="true"
+  else
+    HASH256=$(sha256sum -b "${DOWNLOAD_FILE}" | cut -d " " -f 1)
+    OPTHASH256="hash_sha256=\"${HASH256}\""
   fi
   tee -a /tmp/response > /dev/null <<-EOF
-	<package name="${BASEFILENAME}" hash="${HASH}" size="${SIZE}" required="${REQUIRED}"></package>
+	<package name="${BASEFILENAME}" hash="${HASH}" ${OPTHASH256} size="${SIZE}" required="${REQUIRED}"></package>
 EOF
 done
 


### PR DESCRIPTION
The newer Omaha 3.1 hash_sha256 attribute is now supported by Nebraska and should be used for OEM payloads.
Provide it in addition to the old "hash" attribute for OEM packages (the generic payload uses the Omaha Flatcar extension with the SHA256 hash).


## How to use

With https://github.com/flatcar/update_engine/pull/26

## Testing done


[Jenkins](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/2598/cldsv/): `cl.update.oem` passed.
I've also checked that the `flatcar-update` invocation uses the XML dump.