### PR TITLE
systemd/system/sshkeys: Make execution more robust

### DIFF
--- a/systemd/system/sshkeys.service
+++ b/systemd/system/sshkeys.service
@@ -1,4 +1,9 @@
 [Unit]
+# Don't race and we also want to rely on the folder to be created
+After=update-ssh-keys-after-ignition.service
+
+ConditionPathIsSymbolicLink=!/etc/systemd/system/coreos-metadata-sshkeys@core.service
+
 ConditionKernelCommandLine=|ignition.platform.id=packet
 ConditionKernelCommandLine=|flatcar.oem.id=packet
 ConditionKernelCommandLine=|coreos.oem.id=packet
@@ -22,6 +27,7 @@ ConditionKernelCommandLine=|coreos.oem.id=openstack
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+Restart=on-failure
 ExecStart=/usr/bin/systemctl start coreos-metadata-sshkeys@core.service
 
 [Install]


### PR DESCRIPTION
The service failed when the unit to start was masked. Since it involves
    networking, the service can fail and if it does we should restart. It
    also seems that the service relied on
    update-ssh-keys-after-ignition.service to run update-ssh-keys once to
    create the subfolder and could possibly race with it.

Prevent execution when it has no chance to succeed because the unit to
    start is masked but in all other cases try to restart on failure. Also
    order behind update-ssh-keys-after-ignition.service.


## How to use

Backport

## Testing done

with
```
variant: flatcar
version: 1.0.0
systemd:
  units:
    - name: sshkeys.service
      dropins:
        - name: test.conf
          contents: |
            [Unit]
            After=update-ssh-keys-after-ignition.service
            ConditionPathIsSymbolicLink=!/etc/systemd/system/coreos-metadata-sshkeys@core.service
            [Service]
            Restart=on-failure
```

and verifying that the service does not run when the unit to start is masked.
@tormath1 also checked that the spurious failure experienced when `update-ssh-keys-after-ignition.service` is slower than `sshkeys.service` didn't occur again.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
