### PR TITLE
Restrict Permissions of grub/menu.lst

### DIFF
--- a/systemd/system/boot.mount
+++ b/systemd/system/boot.mount
@@ -9,3 +9,4 @@ ConditionPathExists=!/usr/.noupdate
 [Mount]
 What=/dev/disk/by-label/EFI-SYSTEM
 Where=/boot
+Options=umask=0077


### PR DESCRIPTION
This is described in the following issue:
https://github.com/kinvolk/Flatcar/issues/296

Setting the `Options=umask` parameter as that behaviour is well documented by systemd: https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html#Options.

# Restrict Permissions of grub/menu.lst

Previously the permissions of grub/menu.lst were 0755, this PR corrects those permissions which helps with CIS compliance.

## How to use

Test new unit file works with Flatcar installation.

## Testing done

None yet.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->

Closes: https://github.com/flatcar/Flatcar/issues/296