### PR TITLE
Proxmox support

### DIFF
--- a/systemd/system/sshkeys.service
+++ b/systemd/system/sshkeys.service
@@ -30,6 +30,9 @@ ConditionKernelCommandLine=|flatcar.oem.id=hetzner
 ConditionKernelCommandLine=|ignition.platform.id=akamai
 ConditionKernelCommandLine=|flatcar.oem.id=akamai
 
+ConditionKernelCommandLine=|ignition.platform.id=proxmoxve
+ConditionKernelCommandLine=|flatcar.oem.id=proxmoxve
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
This makes use of https://github.com/coreos/afterburn/pull/1023 to set up the ssh keys from the metadata.

## How to use

see https://github.com/flatcar/bootengine/pull/91

## Testing done

Tested with the community: https://github.com/flatcar/Flatcar/discussions/1573#discussioncomment-11170022