### PR TITLE
udev: Add rule for /dev/ptp_hyperv systemd unit

### DIFF
--- a/udev/rules.d/51-ptp-hyperv.rules
+++ b/udev/rules.d/51-ptp-hyperv.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", TAG+="systemd"


### PR DESCRIPTION
This allows services (such as chrony) to have a dependency on /dev/ptp_hyperv being present.

Inspired by: https://github.com/microsoft/azurelinux/pull/6234.