### PR TITLE
afterburn: set ssh keys for hetzner OEM

### DIFF
--- a/systemd/system/sshkeys.service
+++ b/systemd/system/sshkeys.service
@@ -24,6 +24,9 @@ ConditionKernelCommandLine=|ignition.platform.id=openstack
 ConditionKernelCommandLine=|flatcar.oem.id=openstack
 ConditionKernelCommandLine=|coreos.oem.id=openstack
 
+ConditionKernelCommandLine=|ignition.platform.id=hetzner
+ConditionKernelCommandLine=|flatcar.oem.id=hetzner
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
# Use SSH Keys from metadata service for Hetzner OEM

Enables the existing afterburn service for the `hetzner` OEM. This will read the SSH Key(s) that the user configured for the server from the metadata service, and add them to the `core` user.

## How to use

Changes are pulled into `flatcar/scripts` in https://github.com/flatcar/scripts/pull/1880. This also explains how to use/test them.

## Testing done

I have referenced this commit in `flatcar/scripts` overlay and built a test image. A server created from this image did correctly read and configure the SSH Key. I was able to login and the file `/home/core/.ssh/authorized_keys` contained my key.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

RE the above checkboxes, I was not sure if I should add a changelog, some other recent PRs for Proxmox and Akamai did not add any changelog entries.
