### PR TITLE
Enable veth and bridges on diskless boots.

### DIFF
--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -1,5 +1,7 @@
 [Match]
 Name=*
+Type=!loopback bridge tunnel vxlan wireguard
+Driver=!veth dummy
 KernelCommandLine=!root
 
 [Network]


### PR DESCRIPTION
# Enable veth and bridges on diskless boots.

 Previously a rootless boot would allow systemd-networkd to manage unexpected interfaces, and might interfere with the expected operation of bridges, flannel, and veth interfaces.

## How to use

Boot flatcar via ipxe or via qemu directly with kernel + initrd, but no root kcmdline

## Testing done

Install k3s and observe services to start successfully.

