### PR TITLE
issuegen: read from '/etc/issue.d'

### DIFF
--- a/scripts/issuegen
+++ b/scripts/issuegen
@@ -5,7 +5,7 @@ set -e
 print_issue() {
     echo
     echo 'This is \n (\s \m \r) \t'
-    for note in /run/issue.d/*; do
+    for note in /run/issue.d/* /etc/issue.d/* ; do
         [ -f "${note}" ] && cat "${note}"
     done
     echo


### PR DESCRIPTION
See: https://kubic.opensuse.org/documentation/man-pages/issue.d.5.html

> Files in /etc/issue.d are reserved for the local administrator,
> who may use this logic to override the files installed by vendor packages.
