### PR TITLE
configs: Add modules needed for mounting sysroot

### DIFF
--- a/configs/modules-load.d/initrd.conf
+++ b/configs/modules-load.d/initrd.conf
@@ -1,0 +1,3 @@
+dm_verity
+ext4
+vfat


### PR DESCRIPTION
I haven't tracked the source issue, but dm_verity and ext4 kernel modules are not loaded in initrd (they exist in initrd, but nothing seems to be inserting them into the kernel). The missing dm_verity module causes veritysetup to fail, and missing ext4 module causes mounting rootfs to fail.

Tested in https://github.com/flatcar/scripts/pull/1982.