### PR TITLE
flatcar-install: Remove unnecessary --trusted-key gpg option

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -127,7 +127,6 @@ Flatcar Container Linux on a machine then use this tool to make a permanent inst
 # sub   rsa4096/FCBEAB91 2020-08-28 [S] [expires: 2021-08-28]
 # sub   rsa4096/250D4A42 2021-08-10 [S] [expires: 2022-08-10]
 # sub   rsa4096/267EC954 2022-08-11 [S] [expires: 2023-08-11]
-GPG_LONG_ID="E25D9AED0593B34A"
 GPG_KEY="-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBFqUFawBEACdnSVBBSx3negnGv7Ppf2D6fbIQAHSzUQ+BA5zEG02BS6EKbJh
@@ -686,7 +685,7 @@ function download_from_url(){
         exit 1
     fi
 
-    if ! gpg --batch --trusted-key "${GPG_LONG_ID}" --verify "${WORKDIR}/${SIG_NAME}" "${PWD}/${IMAGE_NAME}"; then
+    if ! gpg --batch --verify "${WORKDIR}/${SIG_NAME}" "${PWD}/${IMAGE_NAME}"; then
         echo "Could not verify ${IMAGE_NAME}." >&2
         exit 1
     fi
@@ -697,8 +696,7 @@ function install_from_url() {
     echo "Downloading, writing and verifying ${IMAGE_NAME}..."
     if ! wget ${WGET_ARGS} --no-verbose -O - "${IMAGE_URL}" \
         | tee >(${BZIP_UTIL} -cd >&3) \
-        | gpg --batch --trusted-key "${GPG_LONG_ID}" \
-            --verify "${WORKDIR}/${SIG_NAME}" -
+        | gpg --batch --verify "${WORKDIR}/${SIG_NAME}" -
     then
         local EEND=( "${PIPESTATUS[@]}" )
         [ ${EEND[0]} -ne 0 ] && echo "${EEND[0]}: Download of ${IMAGE_NAME} did not complete" >&2


### PR DESCRIPTION
# flatcar-install: Remove unnecessary --trusted-key gpg option

Using a custom key was recently broken by a GnuPG update. The Flatcar key is not imported when a custom key is given, but we still reference the Flatcar key with `--trusted-key` regardless, causing gpg to attempt to download the key from a keyserver. This fails because we no longer ship the necessary dirmngr binary, which is now only built when GnuPG has GnuTLS support enabled.

Enabling GnuTLS support works around the problem, but it is not the proper fix. `--trusted-key` causes gpg to trust the given key, even though there is no secret key present. This is unnecessary, as the key would be trusted anyway, albeit with a warning.

Using `--assert-signer` would be safer, as this ensures the file was signed specifically by the given key rather than some other key you happen to have in your keyring. It is not present in older GnuPG versions that we need to support though, and flatcar-install creates a temporary home for gpg, so no other keys would be present anyway.

Closes: https://github.com/flatcar/Flatcar/issues/1471

## How to use

Use flatcar-install as normal, with and without a custom key. For testing a custom key, you can sign any old blob of data and host it somewhere.

You will see the following output.

```
Current version of Flatcar Container Linux stable is 3815.2.3
Downloading the signature for https://stable.release.flatcar-linux.net/amd64-usr/3815.2.3/flatcar_production_image.bin.bz2...
2024-06-21 10:07:35 URL:https://stable.release.flatcar-linux.net/amd64-usr/3815.2.3/flatcar_production_image.bin.bz2.sig [594/594] -> "/tmp/flatcar-install.R2nQpYRQ5A/flatcar_production_image.bin.bz2.sig" [1]
Downloading, writing and verifying flatcar_production_image.bin.bz2...
2024-06-21 10:08:33 URL:https://stable.release.flatcar-linux.net/amd64-usr/3815.2.3/flatcar_production_image.bin.bz2 [467667717/467667717] -> "-" [1]
gpg: Signature made Tue May 21 11:39:55 2024 UTC
gpg:                using RSA key E9426D8B67E35DF476BD048185F7C8868837E271
gpg:                issuer "buildbot@flatcar-linux.org"
gpg: Good signature from "Flatcar Buildbot (Official Builds) <buildbot@flatcar-linux.org>" [unknown]
gpg: WARNING: The key's User ID is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: F88C FEDE FF29 A5B4 D952  3864 E25D 9AED 0593 B34A
     Subkey fingerprint: E942 6D8B 67E3 5DF4 76BD  0481 85F7 C886 8837 E27
```

## Testing done

I tested this under QEMU using the current beta release. For simplicity, I installed to a dummy file.

```
fallocate -l 4G test.img
sudo losetup -f test.img
sudo ./flatcar-install -C stable -d /dev/loop6
```

I also tested using my own key.
 
- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.