### PR TITLE
OEM: IONOS Cloud Images

### DIFF
--- a/systemd/system/oem-cloudinit.service
+++ b/systemd/system/oem-cloudinit.service
@@ -4,7 +4,7 @@ Description=Run cloudinit
 [Service]
 EnvironmentFile=/var/run/ignition.env
 Type=oneshot
-ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gcp rackspace-onmetal azure cloudsigma packet vmware digitalocean openstack); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
+ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gcp rackspace-onmetal azure cloudsigma packet vmware digitalocean openstack ionoscloud); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
 ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws -o "${OEM_ID}" = openstack ]; then echo ec2-compat; elif [ "${OEM_ID}" = gcp ]; then echo gce; else echo "${OEM_ID}" ; fi)"'
 
 [Install]


### PR DESCRIPTION
# Add IONOS Cloud OEM support

Added support for IONOS Cloud in `oem-cloudinit.service` and future support for afterburner in `sshkeys.service`

Replaces #126

## How to use

Used in flatcar/scripts

## Testing done

As part of the build in flatcar/scripts#2389

## PR Requirements
- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.