### PR TITLE
Reload systemd-networkd.service during ensure-sysext

### DIFF
--- a/systemd/system/ensure-sysext.service
+++ b/systemd/system/ensure-sysext.service
@@ -12,6 +12,7 @@ ConditionDirectoryNotEmpty=|/usr/lib/extensions
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/systemctl daemon-reload
+ExecStart=/usr/bin/systemctl reload systemd-networkd.service
 ExecStart=/usr/bin/systemctl restart --no-block sockets.target timers.target multi-user.target
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
# Supports sysexts that configure networkd (for example, tailscale)

Certain sysext extensions, such as tailscale, need to configure networkd (for example, making `tailscale*` interfaces unmanaged).

## Testing done

- Added drop-in that replaced `ensure-sysext` with the above `ExecStart`
- Added newly built `tailscale.raw` from this MR: https://github.com/flatcar/sysext-bakery/pull/106
- Rebooted, checked `systemd-networkd.service` logs to see that it was reconfigured before `tailscale0` interface came up.
