### PR TITLE
systemd: Drop mdmonitor.service dropin

### DIFF
--- a/systemd/system/mdmonitor.service.d/00-syslog.conf
+++ b/systemd/system/mdmonitor.service.d/00-syslog.conf
@@ -1,3 +1,0 @@
-[Service]
-Environment="MDADM_MONITOR_ARGS=--scan --syslog"
-


### PR DESCRIPTION
First, it's not the correct place for such dropins - it ought to be a part of config overrides in scripts repository. Second, it doesn't work anymore - MDADM_MONITOR_ARGS variable is ignored in the systemd unit.

Tested as a part of https://github.com/flatcar/scripts/pull/2814.