### PR TITLE
fix failing install on recycled LVM disk

### DIFF
--- a/bin/flatcar-install
+++ b/bin/flatcar-install
@@ -17,7 +17,7 @@ else
     ensure_tool "${BZIP_UTIL}"
 fi
 
-toolset=( blockdev btrfstune cp cut dd gawk gpg grep head ls lsblk mkdir mkfifo mktemp mount rm sed sort tee udevadm wget wipefs ) 
+toolset=( blockdev btrfstune cp cut dd gawk gpg grep head ls lsblk lvm mkdir mkfifo mktemp mount rm sed sort tee udevadm wget wipefs ) 
 
 for t in "${toolset[@]}"; do ensure_tool "${t}"; done
 
@@ -618,6 +618,10 @@ function get_disk_status() {
 
 function write_to_disk() {
     mkfifo -m 0600 "${WORKDIR}/disk_modified"
+
+    # unconditionally try to deactive any possible auto-activated LVM volume groups
+    # as those will block the modified partition table from being re-read.
+    lvm vgchange -an || true
 
     # We are at the point of no return, so wipe disk labels missed below.
     # In particular, ZFS writes labels in the last half-MiB of the disk.


### PR DESCRIPTION
`flatcar-install` fails on disks, that previously
have had a valid LVM setup on it.
A valid LVM volume group is auto-activated, locks
the original partition table and hence prevents
it from being re-read after writing the Flatcar
raw disk image to the device.

This patch unconditionally deactivates any possibly present auto-activated LVM volume groups to release the device-mapper claim on the partitions table.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
