### PR TITLE
sshkeys: enable SSH keys injection from Scaleway IMDS

### DIFF
--- a/systemd/system/sshkeys.service
+++ b/systemd/system/sshkeys.service
@@ -33,6 +33,9 @@ ConditionKernelCommandLine=|flatcar.oem.id=akamai
 ConditionKernelCommandLine=|ignition.platform.id=proxmoxve
 ConditionKernelCommandLine=|flatcar.oem.id=proxmoxve
 
+ConditionKernelCommandLine=|ignition.platform.id=scaleway
+ConditionKernelCommandLine=|flatcar.oem.id=scaleway
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
In this PR, we enable SSH keys injection from Scaleway IMDS. In case one wants to add SSH keys to the instance without using Ignition.

---

I've tested it and this has been tested by the user reporting the issue as well. 

This has to be backported on some maintainance branches for `init`.