### PR TITLE
Exclude TUN devices from default systemd-networkd setup

### DIFF
--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -6,7 +6,8 @@ IPv6AcceptRA=true
 [Match]
 Name=*
 Type=!loopback bridge tunnel vxlan wireguard
-Driver=!veth dummy
+Driver=!veth tun dummy
+Kind=!tun bridge gre veth wireguard
 
 [DHCP]
 UseMTU=true


### PR DESCRIPTION
The default is to configure a network interface with systemd-networkd but we exclude those devices where it doesn't make sense. This was not done for TUN devices and we should exclude them as well, assuming that the creator would also configure it.
Instead of matching against the "none" type TUN interfaces have, use the driver and kind property to exclude TUN interfaces and a few more while at it (but they are already excluded and we add them just for
completeness).

## How to use

## Testing done

Manual testing on a VM and [kola](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/6868/cldsv/) for all clouds (but we have known failures such as Equnix Metal on arm64)