### PR TITLE
systemd: Add noop sysupdate transfer config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install:
 		$(DESTDIR)/usr/bin \
 		$(DESTDIR)/usr/sbin \
 		$(DESTDIR)/usr/lib/flatcar \
+		$(DESTDIR)/usr/lib/sysupdate.d \
 		$(DESTDIR)/usr/lib/systemd/system \
 		$(DESTDIR)/usr/lib/systemd/network \
 		$(DESTDIR)/usr/lib/systemd/system-generators \
@@ -33,6 +34,7 @@ install:
 	install -m 644 configs/modules-load.d/* $(DESTDIR)/usr/lib/modules-load.d/
 	install -m 644 configs/tmpfiles.d/* $(DESTDIR)/usr/lib/tmpfiles.d/
 	cp -a systemd/* $(DESTDIR)/usr/lib/systemd/
+	cp -a sysupdate.d/* $(DESTDIR)/usr/lib/sysupdate.d/
 	chmod 755 $(DESTDIR)/usr/lib/systemd/system-generators/*
 	ln -sf ../run/issue $(DESTDIR)/etc/issue
 	ln -sfT flatcar $(DESTDIR)/usr/lib/coreos

--- a/sysupdate.d/noop.transfer
+++ b/sysupdate.d/noop.transfer
@@ -1,0 +1,8 @@
+[Source]
+Type=regular-file
+Path=/
+MatchPattern=invalid@v.raw
+[Target]
+Type=regular-file
+Path=/
+MatchPattern=invalid@v.raw


### PR DESCRIPTION
When the systemd-sysupdate.service runs it fails if there is no config. Since we don't use it, it's expected to do nothing but this failure is making problems when the service is started from the timer unit which is now enabled by default. This service is also used by the sysext-bakery update configs for drop-in steps that update sysupdate components. There we let users add a noop config to prevent this service failure.
Since we run into this in Flatcar now and we anyway had users add this manually, let's just add it directly to Flatcar.

## How to use

Needs new scripts PR. Should then be backported to Alpha and Beta.

## Testing done

Was tested in https://github.com/flatcar/scripts/pull/3555
