### PR TITLE
systemd: Change ignition-config-delete failure job mode and make OEM mount stricter

### DIFF
--- a/systemd/system/ignition-delete-config.service
+++ b/systemd/system/ignition-delete-config.service
@@ -16,7 +16,7 @@ DefaultDependencies=no
 Before=sysinit.target
 
 OnFailure=emergency.target
-OnFailureJobMode=isolate
+OnFailureJobMode=replace-irreversibly
 
 [Service]
 Type=oneshot

--- a/systemd/system/oem.mount
+++ b/systemd/system/oem.mount
@@ -13,5 +13,5 @@ ConditionPathExists=!/usr/.noupdate
 What=/dev/disk/by-label/OEM
 Where=/oem
 Options=nodev
-Type=auto
+Type=btrfs,ext4
 LazyUnmount=yes


### PR DESCRIPTION
systemd itself has not used the `isolate` job mode for `emergency.target` since 2013. `replace-irreversibly` does not proactively stop all the other units, just the ones that would block the new target. This can actually make debugging easier because the system will be in a closer state to the one when the failure occurred. I am making the same change in bootengine to fix an issue.

We only expect a disk-based OEM partition to be btrfs or ext4, so don't rely on the `auto` type. This is better for security and probably a smidge faster too.

## How to use

Just test it boots normally.

## Testing done

[Jenkins has passed](https://jenkins.flatcar.org/job/container/job/packages_all_arches/38/cldsv/) with these changes alongside the other wider changes. I have also done lots of manual testing. These changes are not dependent on the wider changes though.